### PR TITLE
Issue17 import warning

### DIFF
--- a/R/validateImport_methods.R
+++ b/R/validateImport_methods.R
@@ -351,11 +351,17 @@ validate_import_numeric <- function(x, field_name, field_min, field_max, logfile
 }
 
 # validate_import_zipcode -------------------------------------------
-
+# Tests to run
+# * values in 12345 and 12345-1234 format pass
+# * NA values pass
+# * unacceptable values produce a message
 validate_import_zipcode <- function(x, field_name, logfile)
 {
   x <- as.character(x)
-  w <- which(!grepl("(\\d{5}|\\d{5}-\\d{4})", x) & !is.na(x))
+  x <- trimws(x)
+  w <- which(!grepl("^(\\d{5}|\\d{5}-\\d{4})$", x) & !is.na(x))
+  
+  x[w] <- rep(NA_character_, length(w))
   
   print_validation_message(
     field_name,

--- a/R/validateImport_methods.R
+++ b/R/validateImport_methods.R
@@ -497,11 +497,21 @@ validate_import_checkbox <- function(x, field_name, field_choice, logfile)
 }
 
 # validate_import_email ---------------------------------------------
+# Tests to run
+# * Common email addresses pass
+# * Invalid e-mail addresses are changed to NA 
+#     - have more than one @
+#     - have no @
+#     - have no suffix
+#     - have a suffix of length one
+#     - have a suffix exceeding length 6
+# * Invalid e-mail addresses produce a message
 
 validate_import_email <- function(x, field_name, logfile)
 {
   x <- as.character(x)
-  w <- which(!grepl("[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+[.][A-Za-z]{2,6}$", x) & !is.na(x))
+  w <- which((!grepl("[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+[.][A-Za-z]{2,6}$", x) |
+                grepl("[@].+[@]", x)) & !is.na(x))
   
   print_validation_message(
     field_name = field_name,

--- a/R/validateImport_methods.R
+++ b/R/validateImport_methods.R
@@ -403,6 +403,11 @@ validate_import_yesno <- function(x, field_name, logfile)
 }
 
 # validate_import_truefalse -----------------------------------------
+# Test to run
+# * true, false, yes, no, 0, and 1 are accepted
+# * NA is accepted
+# * other numeric values produce a message
+# * other character values produce a message
 
 validate_import_truefalse <- function(x, field_name, logfile)
 {

--- a/R/validateImport_methods.R
+++ b/R/validateImport_methods.R
@@ -431,7 +431,11 @@ validate_import_truefalse <- function(x, field_name, logfile)
 }
 
 # validate_import_select_dropdown_radio -----------------------------
-
+# Tests to run
+# mapped pairings with numeric and character codes pass
+# NA passes
+# unmapped values are converted to NA
+# unmapped values produce a message
 validate_import_select_dropdown_radio <- function(x, field_name, field_choice, logfile)
 {
   x <- as.character(x)
@@ -446,6 +450,7 @@ validate_import_select_dropdown_radio <- function(x, field_name, field_choice, l
   }
   
   w <- which(!x %in% mapping[, 1] & !x %in% c('', NA))
+  x[w] <- rep(NA_character_, length(w))
   
   print_validation_message(
     field_name,

--- a/R/validateImport_methods.R
+++ b/R/validateImport_methods.R
@@ -527,31 +527,40 @@ validate_import_email <- function(x, field_name, logfile)
 }
 
 # validate_import_phone ---------------------------------------------
+# Tests to perform
+# * valid phone numbers pass
+# * NA passes
+# * phone numbers of more than 10 digits become NA
+# * phone numbers of more than 10 digits produce a message
+# * phone numbers with invalid format become NA
+# * phone numbers with invalid format produce a message
 
 validate_import_phone <- function(x, field_name, logfile)
 {
   x <- as.character(x)
   x <- gsub("[[:punct:][:space:]]", "", x)
   
-  w_long <- which(nchar(x) != 10 & !is.na(x))
+  w_long <- nchar(x) != 10 & !is.na(x)
   
-  w_invalid <- which(grepl("^[2-9][0-8][0-9][2-9][0-9]{6}$", x))
+  w_invalid <- !grepl("^[2-9][0-8][0-9][2-9][0-9]{6}$", x) & !is.na(x)
   
   print_validation_message(
     field_name = field_name,
-    indices = w_long,
+    indices = which(w_long),
     message = paste0("Value(s) are not 10 digit phone numbers.\n",
-                     "Values not imported.")
+                     "Values not imported."), 
+    logfile = logfile
   )
   
   print_validation_message(
     field_name = field_name,
-    indices = w_long,
+    indices = which(w_invalid),
     message = paste0("Value(s) are not valid North American phone numbers.\n",
-                     "Values not imported.")
+                     "Values not imported."), 
+    logfile = logfile
   )
   
-  x[w_long | w_invalid] <- NA
+  x[w_long | w_invalid] <- NA_character_
   x
 }
 

--- a/R/validateImport_methods.R
+++ b/R/validateImport_methods.R
@@ -1,4 +1,12 @@
 # validate_import_form_complete -------------------------------------
+# Tests to perform 
+# * The following values are mapped
+#     Incomplete to 0
+#     Unverified to 1
+#     Complete to 2
+# * 0, 1, and 2 are returned unchanged
+# * NA values are silently ignored (no output)
+# * any other value produces a validation message
 
 validate_import_form_complete <- function(x, field_name, logfile)
 {
@@ -12,8 +20,9 @@ validate_import_form_complete <- function(x, field_name, logfile)
   x <- gsub(pattern = "Complete", 
             replacement = "2", 
             x = x)
+  x <- trimws(x)
   
-  w <- which(!grepl("[0-2]", x = x))
+  w <- which((!x %in% 0:2) & !is.na(x))
   x[w] <- NA
   
   print_validation_message(
@@ -28,9 +37,16 @@ validate_import_form_complete <- function(x, field_name, logfile)
 }
 
 # validate_import_date ----------------------------------------------
+# * Date and POSIXct values are returned in YYYY-mm-dd format
+# * map ymd, ymd HMS, mdy, mdy HMS, dmy, and dmy HMS strings to YYYY-mm-dd format
+# * NA values pass silently
+# * Unmappable values return a message
+# * When a date is less than field_min, a message is returned.
+# * When a date is greater than field_max, a message is returned.
 
 validate_import_date <- function(x, field_name, field_min, field_max, logfile)
 {
+  x_orig <- x
   if (!inherits(x, "Date") && !inherits(x, "POSIXct"))
   {
     suppressWarnings(
@@ -40,7 +56,7 @@ validate_import_date <- function(x, field_name, field_min, field_max, logfile)
                                                  "dmy", "dmy HMS"))
     )
   }
-
+  
   w_low <- which(as.POSIXct(x) < as.POSIXct(field_min, origin = "1970-01-01"))
   print_validation_message(
     field_name,
@@ -62,7 +78,7 @@ validate_import_date <- function(x, field_name, field_min, field_max, logfile)
   
   x <- format(x, format = "%Y-%m-%d")
   
-  w <- which(is.na(x))
+  w <- which(is.na(x) & !x_orig %in% c('', NA))
   
   print_validation_message(
     field_name, 
@@ -76,9 +92,15 @@ validate_import_date <- function(x, field_name, field_min, field_max, logfile)
 }
 
 # validate_import_datetime ------------------------------------------
-
+# * Date and POSIXct values are returned in YYYY-mm-dd HH:MM format
+# * map ymd, ymd HMS, mdy, mdy HMS, dmy, and dmy HMS strings to YYYY-mm-dd HH:MM format
+# * NA values pass silently
+# * Unmappable values return a message
+# * When a date is less than field_min, a message is returned.
+# * When a date is greater than field_max, a message is returned.
 validate_import_datetime <- function(x, field_name, field_min, field_max, logfile)
 {
+  x_orig <- x
   if (!inherits(x, "Date") && !inherits(x, "POSIXct"))
   {
     suppressWarnings(
@@ -109,7 +131,7 @@ validate_import_datetime <- function(x, field_name, field_min, field_max, logfil
   
   x <- format(x, format = "%Y-%m-%d %H:%M")
   
-  w <- which(is.na(x))
+  w <- which(is.na(x) & !x_orig %in% c('', NA))
   
   print_validation_message(
     field_name, 
@@ -123,9 +145,15 @@ validate_import_datetime <- function(x, field_name, field_min, field_max, logfil
 }
 
 # validate_import_datetime_seconds ----------------------------------
-
+# * Date and POSIXct values are returned in YYYY-mm-dd HH:MM format
+# * map ymd, ymd HMS, mdy, mdy HMS, dmy, and dmy HMS strings to YYYY-mm-dd HH:MM format
+# * NA values pass silently
+# * Unmappable values return a message
+# * When a date is less than field_min, a message is returned.
+# * When a date is greater than field_max, a message is returned.
 validate_import_datetime_seconds <- function(x, field_name, field_min, field_max, logfile)
 {
+  x_orig <- x
   if (!inherits(x, "Date") && !inherits(x, "POSIXct"))
   {
     suppressWarnings(
@@ -156,7 +184,7 @@ validate_import_datetime_seconds <- function(x, field_name, field_min, field_max
   
   x <- format(x, format = "%Y-%m-%d %H:%M:%S")
   
-  w <- which(is.na(x))
+  w <- which(is.na(x) & !x_orig %in% c('', NA))
   
   print_validation_message(
     field_name, 
@@ -226,7 +254,7 @@ validate_import_time_mm_ss <- function(x, field_name, field_min, field_max, logf
   x[grepl("^\\d{2}:\\d{2}:\\d{2}$", x)] <- 
     sub("^\\d{2}:", "", x[grepl("^\\d{2}:\\d{2}:\\d{2}$", x)])
   
-  w_invalid <- !grepl("^\\d{2}:\\d{2}$", x)
+  w_invalid <- !grepl("^\\d{2}:\\d{2}$", x) & !is.na(x)
   x[w_invalid] <- NA
   
   count_second <- function(t)
@@ -384,7 +412,7 @@ validate_import_select_dropdown_radio <- function(x, field_name, field_choice, l
   for (i in seq_len(nrow(mapping))){
     x[x==mapping[i, 2]] <- mapping[i, 1]  
   }
-
+  
   w <- which(!x %in% mapping[, 1] & !x %in% c('', NA))
   
   print_validation_message(
@@ -412,7 +440,7 @@ validate_import_checkbox <- function(x, field_name, field_choice, logfile)
   checkChoice <- checkChoice[checkChoice[, 1] == unlist(strsplit(field_name, "___"))[2], ]
   
   w <- which(!x %in% c("Checked", "Unchecked", "0", "1", checkChoice, "") & !is.na(x))
-
+  
   x <- gsub("checked", "1", x)
   x <- gsub("unchecked", "0", x)
   x[x %in% checkChoice] <- 1

--- a/R/validateImport_methods.R
+++ b/R/validateImport_methods.R
@@ -375,12 +375,18 @@ validate_import_zipcode <- function(x, field_name, logfile)
 }
 
 # validate_import_yesno ---------------------------------------------
+# Test to run
+# * yes, no, 0, and 1 are accepted
+# * NA is accepted
+# * other numeric values produce a message
+# * other character values produce a message
 
 validate_import_yesno <- function(x, field_name, logfile)
 {
   x <- as.character(x)
   x <- tolower(x)
   w <- which(!x %in% c("no", "yes", "0", "1") & !is.na(x))
+  x[w] <- rep(NA_character_, length(w))
   
   x <- gsub("no", "0", x)
   x <- gsub("yes", "1", x)

--- a/R/validateImport_methods.R
+++ b/R/validateImport_methods.R
@@ -198,7 +198,12 @@ validate_import_datetime_seconds <- function(x, field_name, field_min, field_max
 }
 
 # validate_import_time ----------------------------------------------
-
+# Tests to perform
+# * character forms of HH:MM and HH:MM:SS pass
+# * objects of class time pass
+# * NA passes
+# * times before field_min produce a message
+# * times after field_max produce a message
 validate_import_time <- function(x, field_name, field_min, field_max, logfile)
 {
   x <- as.character(x)
@@ -208,13 +213,13 @@ validate_import_time <- function(x, field_name, field_min, field_max, logfile)
   
   count_minute <- function(t)
   {
-    if (is.na(t)) return(NA)
+    if (is.na(t)) return(NA_real_)
     t <- strsplit(t, ":")
     t <- unlist(t)
     t <- as.numeric(t)
     t[1] * 60 + t[2]
   }
-  
+
   total_min <- vapply(x, count_minute, numeric(1))
   
   print_validation_message(
@@ -246,7 +251,12 @@ validate_import_time <- function(x, field_name, field_min, field_max, logfile)
 }
 
 # validate_import_time_mm_ss ----------------------------------------
-
+# Tests to perform
+# * character forms of HH:MM and HH:MM:SS pass
+# * objects of class time pass
+# * NA passes
+# * times before field_min produce a message
+# * times after field_max produce a message
 validate_import_time_mm_ss <- function(x, field_name, field_min, field_max, logfile)
 {
   x <- as.character(x)
@@ -296,7 +306,12 @@ validate_import_time_mm_ss <- function(x, field_name, field_min, field_max, logf
 }
 
 # validate_import_numeric -------------------------------------------
-
+# Tests to perform
+# * values that can be coerced to numeric pass.
+# * NA passes
+# * Values that cannot be coerced to numeric produce a message
+# * values less than field_min produce a message
+# * values greater than field_max produce a message
 validate_import_numeric <- function(x, field_name, field_min, field_max, logfile)
 {
   suppressWarnings(num_check <- as.numeric(x))

--- a/tests/testthat/test-validateImport_methods.R
+++ b/tests/testthat/test-validateImport_methods.R
@@ -671,3 +671,57 @@ test_that(
     )
   }
 )
+
+# validate_import_zipcode -------------------------------------------
+
+test_that(
+  "values in 12345, format or NA pass (from numeric)",
+  {
+    test_zip <- c(48169, NA_real_)
+    expect_equal(
+      validate_import_zipcode(test_zip, 
+                              field_name = "zip", 
+                              logfile = ""), 
+      c("48169", NA_character_)
+    )
+  }
+)
+
+test_that(
+  "values in 12345, 12345-1234 format or NA pass (from character)",
+  {
+    test_zip <- c("48169", "48169-0133", NA_real_)
+    expect_equal(
+      validate_import_zipcode(test_zip, 
+                              field_name = "zip", 
+                              logfile = ""), 
+      c("48169", "48169-0133", NA_real_)
+    )
+  }
+)
+
+test_that(
+  "values not in 12345 or 12345-1234 format are converted to NA (so they won't write)",
+  {
+    test_zip <- c("8169", "48169-01", "48169-abc", "zipcode")
+    expect_equal(
+      validate_import_zipcode(test_zip, 
+                              field_name = "zip", 
+                              logfile = ""),
+      rep(NA_character_, length(test_zip))
+    )
+  }
+)
+
+test_that(
+  "values not in 12345 or 12345-1234 format produce a message",
+  {
+    test_zip <- c("8169", "48169-01", "48169-abc", "zipcode")
+    expect_message(
+      validate_import_zipcode(test_zip, 
+                              field_name = "zip", 
+                              logfile = ""),
+      "must be in the format `12345` or `12345-1234`"
+    )
+  }
+)

--- a/tests/testthat/test-validateImport_methods.R
+++ b/tests/testthat/test-validateImport_methods.R
@@ -141,6 +141,7 @@ test_that(
 test_that(
   "Unmappable values return a message", 
   {
+    local_reproducible_output(width = 200)
     expect_message(
       validate_import_date(c("2023-01-33", "not a date"), 
                            field_name = "date",
@@ -155,6 +156,7 @@ test_that(
 test_that(
   "When a date is less than field_min, a message is returned", 
   {
+    local_reproducible_output(width = 200)
     expect_message(
       validate_import_date(as.Date(c("2023-01-01", "2023-03-01")), 
                            field_name = "date", 
@@ -169,6 +171,7 @@ test_that(
 test_that(
   "When a date is greater than field_max, a message is returned", 
   {
+    local_reproducible_output(width = 200)
     expect_message(
       validate_import_date(as.Date(c("2023-01-01", "2023-03-01")), 
                            field_name = "date", 
@@ -289,6 +292,7 @@ test_that(
 test_that(
   "Unmappable values return a message", 
   {
+    local_reproducible_output(width = 200)
     expect_message(
       validate_import_datetime(c("2023-01-33", "not a date"), 
                                field_name = "datetime",
@@ -303,6 +307,7 @@ test_that(
 test_that(
   "When a date is less than field_min, a message is returned", 
   {
+    local_reproducible_output(width = 200)
     expect_message(
       validate_import_datetime(as.POSIXct(c("2023-01-01", "2023-03-01")), 
                                field_name = "date", 
@@ -317,6 +322,7 @@ test_that(
 test_that(
   "When a date is greater than field_max, a message is returned", 
   {
+    local_reproducible_output(width = 200)
     expect_message(
       validate_import_datetime(as.Date(c("2023-01-01", "2023-03-01")), 
                                field_name = "date", 
@@ -472,6 +478,196 @@ test_that(
                                        field_max = as.POSIXct("2023-02-01"), 
                                        logfile = ""), 
       "after the stated maximum date"
+    )
+  }
+)
+
+# validate_import_time ----------------------------------------------
+
+test_that(
+  "Character forms of HH:MM and HH:MM:SS pass", 
+  {
+    time_test <- c("06:15", "06:15:00")
+    expect_equal(
+      validate_import_time(time_test, 
+                           field_name = "time", 
+                           field_min = NA, 
+                           field_max = NA, 
+                           logfile = ""), 
+      rep("06:15", 2)
+    )
+  }
+)
+
+test_that(
+  "objects of class time pass. Also, NA",
+  {
+    time_test <- chron::as.times(c("06:15:00", NA))
+    expect_equal(
+      validate_import_time(time_test, 
+                           field_name = "time", 
+                           field_min = NA, 
+                           field_max = NA, 
+                           logfile = ""), 
+      c("06:15", NA)
+    )
+  }
+)
+
+test_that(
+  "Times before field_min produce a message",
+  {
+    time_test <- c("06:00", "07:00", "08:00", "09:00")
+    expect_message(
+      validate_import_time(time_test, 
+                           field_name = "time", 
+                           field_min = "07:30", 
+                           field_max = NA, 
+                           logfile = ""), 
+      "are before the stated minimum time"
+    )
+  }
+)
+
+test_that(
+  "Times after field_max produce a message",
+  {
+    time_test <- c("06:00", "07:00", "08:00", "09:00")
+    expect_message(
+      validate_import_time(time_test, 
+                           field_name = "time", 
+                           field_min = NA, 
+                           field_max = "07:30", 
+                           logfile = ""), 
+      "are after the stated maximum time"
+    )
+  }
+)
+
+# validate_import_time_mm_ss ----------------------------------------
+
+test_that(
+  "Character forms of HH:MM and HH:MM:SS pass", 
+  {
+    time_test <- c("06:15", "00:06:15")
+    expect_equal(
+      validate_import_time_mm_ss(time_test, 
+                           field_name = "time", 
+                           field_min = NA, 
+                           field_max = NA, 
+                           logfile = ""), 
+      rep("06:15", 2)
+    )
+  }
+)
+
+test_that(
+  "objects of class time pass. Also, NA",
+  {
+    time_test <- chron::as.times(c("00:06:15", NA))
+    expect_equal(
+      validate_import_time_mm_ss(time_test,
+                                 field_name = "time",
+                                 field_min = NA,
+                                 field_max = NA,
+                                 logfile = ""),
+      c("06:15", NA)
+    )
+  }
+)
+
+test_that(
+  "Times before field_min produce a message",
+  {
+    local_reproducible_output(width = 200)
+    time_test <- c("06:00", "07:00", "08:00", "09:00")
+    expect_message(
+      validate_import_time_mm_ss(time_test,
+                                 field_name = "time",
+                                 field_min = "07:30",
+                                 field_max = NA,
+                                 logfile = ""),
+      "are before the stated minimum time"
+    )
+  }
+)
+
+test_that(
+  "Times after field_max produce a message",
+  {
+    local_reproducible_output(width = 200)
+    time_test <- c("06:00", "07:00", "08:00", "09:00")
+    expect_message(
+      validate_import_time_mm_ss(time_test,
+                                 field_name = "time",
+                                 field_min = NA,
+                                 field_max = "07:30",
+                                 logfile = ""),
+      "are after the stated maximum time"
+    )
+  }
+)
+# validate_import_numeric -------------------------------------------
+
+test_that(
+  "Values that can be coerced to numeric pass (including NA)", 
+  {
+    test_numeric <- c("1.2", pi, NA_character_)
+    expect_equal(
+      validate_import_numeric(test_numeric, 
+                              field_name = "numeric", 
+                              field_min = NA, 
+                              field_max = NA, 
+                              logfile = ""), 
+      c(1.2, pi, NA_real_)
+    )
+  }
+)
+
+test_that(
+  "Values that cannot be coerced to numeric produce a message", 
+  {
+    local_reproducible_output(width = 200)
+    test_numeric <- c("a", "b", pi)
+    expect_message(
+      validate_import_numeric(test_numeric, 
+                              field_name = "numeric", 
+                              field_min = NA, 
+                              field_max = NA, 
+                              logfile = ""), 
+      "must be numeric or coercible to numeric"
+    )
+  }
+)
+
+test_that(
+  "Values less than field_min produce a message", 
+  {
+    local_reproducible_output(width = 200)
+    test_numeric <- 1:5
+    expect_message(
+      validate_import_numeric(test_numeric, 
+                              field_name = "numeric", 
+                              field_min = 3, 
+                              field_max = NA, 
+                              logfile = ""),
+      "are less than the stated minimum"
+    )
+  }
+)
+
+test_that(
+  "Values less than field_min produce a message", 
+  {
+    local_reproducible_output(width = 200)
+    test_numeric <- 1:5
+    expect_message(
+      validate_import_numeric(test_numeric, 
+                              field_name = "numeric", 
+                              field_min = NA, 
+                              field_max = 3, 
+                              logfile = ""),
+      "are greater than the stated maximum"
     )
   }
 )

--- a/tests/testthat/test-validateImport_methods.R
+++ b/tests/testthat/test-validateImport_methods.R
@@ -898,3 +898,97 @@ test_that(
   }
 )
 
+
+# validate_import_select_dropdown_radio -----------------------------
+
+test_that(
+  "mapped pairings with numeric and character codes pass (also NA)",
+  {
+    test_select <- c("-1", "0", "1", "a", "abc", 
+                     "negative one", "zero", "one", "A", "ABC", 
+                     NA_character_)
+    mapping <- "-1, negative one | 0, zero | 1, one | a, A | abc, ABC"
+    expect_equal(
+      validate_import_select_dropdown_radio(test_select, 
+                                            field_name = "select", 
+                                            field_choice = mapping, 
+                                            logfile = ""), 
+      c("-1", "0", "1", "a", "abc", 
+        "-1", "0", "1", "a", "abc", 
+        NA_character_)
+    )
+  }
+)
+
+test_that(
+  "mapped pairings with numeric and character codes pass (also NA)",
+  {
+    test_select <- c(-1, 0, 1, NA_real_)
+    mapping <- "-1, negative one | 0, zero | 1, one | a, A | abc, ABC"
+    expect_equal(
+      validate_import_select_dropdown_radio(test_select, 
+                                            field_name = "select", 
+                                            field_choice = mapping, 
+                                            logfile = ""), 
+      c("-1", "0", "1",NA_character_)
+    )
+  }
+)
+
+test_that(
+  "unmapped values are converted to NA (character)", 
+  {
+    mapping <- "-1, negative one | 0, zero | 1, one | a, A | abc, ABC"
+    expect_equal(
+      validate_import_select_dropdown_radio(c("XYZ", "15"), 
+                                            field_name = "select", 
+                                            field_choice = mapping, 
+                                            logfile = ""), 
+      c(NA_character_, NA_character_)
+    )
+  }
+)
+
+test_that(
+  "unmapped values are converted to NA (numeric)", 
+  {
+    mapping <- "-1, negative one | 0, zero | 1, one | a, A | abc, ABC"
+    expect_equal(
+      validate_import_select_dropdown_radio(c(pi, 10), 
+                                            field_name = "select", 
+                                            field_choice = mapping, 
+                                            logfile = ""), 
+      c(NA_character_, NA_character_)
+    )
+  }
+)
+
+test_that(
+  "unmapped values produce a message (character)", 
+  {
+    local_reproducible_output(width = 200)
+    mapping <- "-1, negative one | 0, zero | 1, one | a, A | abc, ABC"
+    expect_message(
+      validate_import_select_dropdown_radio(c("XYZ", "15"), 
+                                            field_name = "select", 
+                                            field_choice = mapping, 
+                                            logfile = ""), 
+      "must be one of '-1', '0', '1', 'a', 'abc', 'negative one', 'zero', 'one', 'A', 'ABC'"
+    )
+  }
+)
+
+test_that(
+  "unmapped values produce a message (numeric)", 
+  {
+    local_reproducible_output(width = 200)
+    mapping <- "-1, negative one | 0, zero | 1, one | a, A | abc, ABC"
+    expect_message(
+      validate_import_select_dropdown_radio(c(pi, 10), 
+                                            field_name = "select", 
+                                            field_choice = mapping, 
+                                            logfile = ""), 
+      "must be one of '-1', '0', '1', 'a', 'abc', 'negative one', 'zero', 'one', 'A', 'ABC'"
+    )
+  }
+)

--- a/tests/testthat/test-validateImport_methods.R
+++ b/tests/testthat/test-validateImport_methods.R
@@ -1047,3 +1047,96 @@ test_that(
     )
   }
 )
+
+# validate_import_phone ---------------------------------------------
+
+test_that(
+  "valid phone numbers pass (including NA)", 
+  {
+    phone_punct <- c("(207) 555-1234", 
+                     "207.555.1234", 
+                     "207-555-1234", 
+                     "207 555 1234")
+    # to test all valid phone numbers would be overly tedious. 
+    # we'll just a sample. Change n_size to match your desired rigor
+    n_size <- 10
+    phone_random <- sprintf("%s%s%s %s%s%s %s%s%s%s", 
+                            sample(2:9, n_size, replace = TRUE), 
+                            sample(0:8, n_size, replace = TRUE), 
+                            sample(0:9, n_size, replace = TRUE), 
+                            sample(2:9, n_size, replace = TRUE), 
+                            sample(0:9, n_size, replace = TRUE),
+                            sample(0:9, n_size, replace = TRUE),
+                            sample(0:9, n_size, replace = TRUE),
+                            sample(0:9, n_size, replace = TRUE),
+                            sample(0:9, n_size, replace = TRUE),
+                            sample(0:9, n_size, replace = TRUE))
+    test_phone <- c(phone_punct, phone_random, NA_character_)
+    
+    expect_equal(
+      validate_import_phone(test_phone, 
+                            field_name = "phone", 
+                            logfile = ""),
+      gsub("[[:punct:][:space:]]", "", test_phone)
+    )
+  }
+)
+
+test_that(
+  "phone numbers of more than 10 digits become NA",
+  {
+    expect_equal(
+      validate_import_phone(c("555-555-5555-5", 
+                              "555-555-5555-5555"), 
+                            field_name = "phone", 
+                            logfile = ""), 
+      c(NA_character_, NA_character_)
+    )
+  }
+)
+
+test_that(
+  "phone numbers of more than 10 digits produce a message",
+  {
+    expect_message(
+      validate_import_phone(c("555-555-5555-5", 
+                              "555-555-5555-5555"), 
+                            field_name = "phone", 
+                            logfile = ""), 
+      "are not 10 digit phone numbers"
+    )
+  }
+)
+
+test_that(
+  "phone numbers with invalid format become NA",
+  {
+    # The fives are valid digits. The non-five digits
+    # are placed where those values are not allowed
+    expect_equal(
+      validate_import_phone(c("055-555-5555",
+                              "155-555-5555", 
+                              "595-555-5555", 
+                              "555-155-5555"), 
+                            field_name = "phone", 
+                            logfile = ""), 
+      c(NA_character_, NA_character_, NA_character_, NA_character_)
+    )
+  }
+)
+
+test_that(
+  "phone numbers with invalid format produce a message",
+  {
+    expect_message(
+      validate_import_phone(c("055-555-5555",
+                              "155-555-5555", 
+                              "595-555-5555", 
+                              "555-155-5555"), 
+                            field_name = "phone", 
+                            logfile = ""), 
+      "are not valid North American phone numbers"
+    )
+  }
+)
+

--- a/tests/testthat/test-validateImport_methods.R
+++ b/tests/testthat/test-validateImport_methods.R
@@ -800,3 +800,101 @@ test_that(
     )
   }
 )
+
+# validate_import_truefalse -----------------------------------------
+
+test_that(
+  "true, false, yes, no, 0, 1, and NA are accepted (character)",
+  {
+    test_true_false <- c("true", "True", "TRUE", "truE", 
+                         "false", "False", "FALSE", "falsE", 
+                         "yes", "Yes", "YES", "yeS", 
+                         "no", "No", "NO", "nO", 
+                         "0", "1", NA_character_)
+    expect_equal(
+      validate_import_truefalse(test_true_false, 
+                                field_name = "truefalse", 
+                                logfile = ""), 
+      as.character(c(1, 1, 1, 1, 
+                     0, 0, 0, 0, 
+                     1, 1, 1, 1,
+                     0, 0, 0, 0, 
+                     0, 1, NA_real_))
+    )
+  }
+)
+
+test_that(
+  "0, 1, and NA are accepted (numeric)",
+  {
+    test_true_false <- c(0, 1, NA_real_)
+    expect_equal(
+      validate_import_truefalse(test_true_false, 
+                                field_name = "truefalse", 
+                                logfile = ""), 
+      as.character(c(0, 1, NA_real_))
+    )
+  }
+)
+
+test_that(
+  "TRUE, FALSE, and NA are accepted (logical)",
+  {
+    test_true_false <- c(TRUE, FALSE, NA)
+    expect_equal(
+      validate_import_truefalse(test_true_false, 
+                                field_name = "truefalse", 
+                                logfile = ""), 
+      as.character(c(1, 0, NA_real_))
+    )
+  }
+)
+
+test_that(
+  "Unacceptable values are converted to NA to prevent writing (character)",
+  {
+    expect_equal(
+      validate_import_truefalse(c("negative", "affirmative"), 
+                                field_name = "truefalse", 
+                                logfile = ""), 
+      rep(NA_character_, 2)
+    )
+  }
+)
+
+test_that(
+  "unacceptable values produce a message (character)", 
+  {
+    expect_message(
+      validate_import_truefalse(c("negative", "affirmative"), 
+                                field_name = "truefalse", 
+                                logfile = ""), 
+      "must be one of logical or one of `0`, `1`, `No`, `Yes`, `False`, or `True`"
+    )
+  }
+)
+
+test_that(
+  "Unacceptable values are converted to NA to prevent writing (numeric)",
+  {
+    expect_equal(
+      validate_import_truefalse(c(-1, pi, 12), 
+                                field_name = "truefalse", 
+                                logfile = ""), 
+      rep(NA_character_, 3)
+    )
+  }
+)
+
+test_that(
+  "unacceptable values produce a message (numeric)", 
+  {
+    expect_message(
+      validate_import_truefalse(c(-1, pi, 12), 
+                            field_name = "truefalse", 
+                            logfile = ""), 
+      "must be one of logical or one of `0`, `1`, `No`, `Yes`, `False`, or `True`"
+    )
+  }
+)
+

--- a/tests/testthat/test-validateImport_methods.R
+++ b/tests/testthat/test-validateImport_methods.R
@@ -992,3 +992,58 @@ test_that(
     )
   }
 )
+
+# validate_import_email ---------------------------------------------
+
+test_that(
+  "common email addresses pass", 
+  {
+    email <- c("somebody@domain.net", 
+               "some.body1@domain.org", 
+               "345somebody789@domain.net", 
+               "somebody-else@domain.com", 
+               "salesperson@dash-company.biz", 
+               "percy_jackson@camp-half-blood.edu", 
+               "someone+spam@domain.widget", 
+               "high%shooting@sports.ball", 
+               NA_character_)
+    expect_equal(
+      validate_import_email(email, 
+                            field_name = "email", 
+                            logfile = ""), 
+      email
+    )
+  }
+)
+
+test_that(
+  "Invalid e-mails are changed to NA", 
+  {
+    email <- c("Im@work@nowhere.net", 
+               "no-suffix@junkmail", 
+               "one-length-suffix@email.g", 
+               "long-suffix@email.sunburst")
+    expect_equal(
+      validate_import_email(email, 
+                            field_name = "email", 
+                            logfile = ""),
+      rep(NA_character_, length(email))
+    )
+  }
+)
+
+test_that(
+  "Invalid e-mails are changed to NA", 
+  {
+    email <- c("Im@work@nowhere.net", 
+               "no-suffix@junkmail", 
+               "one-length-suffix@email.g", 
+               "long-suffix@email.sunburst")
+    expect_message(
+      validate_import_email(email, 
+                            field_name = "email", 
+                            logfile = ""),
+      "are not valid e-mail addresses"
+    )
+  }
+)

--- a/tests/testthat/test-validateImport_methods.R
+++ b/tests/testthat/test-validateImport_methods.R
@@ -725,3 +725,78 @@ test_that(
     )
   }
 )
+# validate_import_yesno ---------------------------------------------
+
+test_that(
+  "yes, no, 0, 1, and NA are accepted (character)",
+  {
+    test_yes_no <- c("no", "yes", "0", "1", "No", "Yes", "NO", "YEs", "YES", NA_character_)
+    expect_equal(
+      validate_import_yesno(test_yes_no, 
+                            field_name = "yesno", 
+                            logfile = ""), 
+      as.character(c(0, 1, 0, 1, 0, 1, 0, 1, 1, NA_real_))
+    )
+  }
+)
+
+test_that(
+  "0, 1, and NA are accepted (numeric)",
+  {
+    test_yes_no <- c(0, 1, NA_real_)
+    expect_equal(
+      validate_import_yesno(test_yes_no, 
+                            field_name = "yesno", 
+                            logfile = ""), 
+      as.character(c(0, 1, NA_real_))
+    )
+  }
+)
+
+test_that(
+  "Unacceptable values are converted to NA to prevent writing (character)",
+  {
+    expect_equal(
+      validate_import_yesno(c("negative", "affirmative"), 
+                            field_name = "yesno", 
+                            logfile = ""), 
+      rep(NA_character_, 2)
+    )
+  }
+)
+
+test_that(
+  "unacceptable values produce a message (character)", 
+  {
+    expect_message(
+      validate_import_yesno(c("negative", "affirmative"), 
+                            field_name = "yesno", 
+                            logfile = ""), 
+      "must be one of `0`, `1`, `No`, or `Yes`"
+    )
+  }
+)
+
+test_that(
+  "Unacceptable values are converted to NA to prevent writing (numeric)",
+  {
+    expect_equal(
+      validate_import_yesno(c(-1, pi, 12), 
+                            field_name = "yesno", 
+                            logfile = ""), 
+      rep(NA_character_, 3)
+    )
+  }
+)
+
+test_that(
+  "unacceptable values produce a message (numeric)", 
+  {
+    expect_message(
+      validate_import_yesno(c(-1, pi, 12), 
+                            field_name = "yesno", 
+                            logfile = ""), 
+      "must be one of `0`, `1`, `No`, or `Yes`"
+    )
+  }
+)

--- a/tests/testthat/test-validateImport_methods.R
+++ b/tests/testthat/test-validateImport_methods.R
@@ -1,0 +1,477 @@
+context("validateImport_methods.R")
+
+# Tests for validate_import_form_complete ---------------------------
+
+test_that(
+  "Acceptable values are properly mapped and returned.", 
+  {
+    input_value <- c("Incomplete", "Unverified", "Complete", 
+                     "0",          "1",          "2", 
+                     NA)
+    expect_equal(
+      validate_import_form_complete(input_value,
+                                    field_name = "form_complete", 
+                                    logfile = ""), 
+      c("0", "1", "2", 
+        "0", "1", "2", 
+        NA)
+    )
+  }
+)
+
+test_that(
+  "Unacceptable values return a message", 
+  {
+    local_reproducible_output(width = 200)
+    expect_message(
+      validate_import_form_complete("Invalid", 
+                                    field_name = "form_complete", 
+                                    logfile = ""), 
+      "Values[(]s[)] must be one of: 0, 1, 2, Incomplete, Unverified, or Complete."
+    )
+  }
+)
+
+
+# validate_import_date ----------------------------------------------
+
+test_that(
+  "Date values are converted to YYYY-mm-dd format", 
+  {
+    date_test <- Sys.Date()
+    expect_equal(
+      validate_import_date(date_test,  
+                           field_name = "date",
+                           field_min = NA, 
+                           field_max = NA, 
+                           logfile = ""),
+      format(date_test, "%Y-%m-%d")
+    )
+  }
+)
+
+test_that(
+  "POSIXct values are converted to YYYY-mm-dd format", 
+  {
+    datetime_test <- Sys.time()
+    expect_equal(
+      validate_import_date(datetime_test,  
+                           field_name = "date",
+                           field_min = NA, 
+                           field_max = NA, 
+                           logfile = ""),
+      format(datetime_test, "%Y-%m-%d")
+    )
+  }
+)
+
+test_that(
+  "ymd, ymd HMS map to YYYY-mm-dd format",
+  {
+    test_strings <- c("2023-01-01", "2023-01-02 03:04:05")
+    
+    compare_string <- seq(from = as.Date("2023-01-01"), 
+                          to = as.Date("2023-01-02"), 
+                          by = "1 day")
+    compare_string <- format(compare_string, 
+                             format = "%Y-%m-%d")
+    expect_equal(
+      validate_import_date(test_strings,  
+                           field_name = "date",
+                           field_min = NA, 
+                           field_max = NA, 
+                           logfile = ""), 
+      compare_string
+    )
+  }
+)
+
+test_that(
+  "mdy, mdy HMS YYYY-mm-dd format",
+  {
+    test_strings <- c("01-01-2023", "01-02-2023 03:04:05")
+    
+    compare_string <- as.Date(c("2023-01-01", "2023-01-02"))
+    compare_string <- format(compare_string, 
+                             format = "%Y-%m-%d")
+    expect_equal(
+      validate_import_date(test_strings,  
+                           field_name = "date",
+                           field_min = NA, 
+                           field_max = NA, 
+                           logfile = ""), 
+      compare_string
+    )
+  }
+)
+
+test_that(
+  "dmy, dmy HMS YYYY-mm-dd format",
+  {
+    test_strings <- c("13-01-2023", "01-01-2023 03:04:05")
+    
+    compare_string <- as.Date(c("2023-01-13", "2023-01-01"))
+    compare_string <- format(compare_string, 
+                             format = "%Y-%m-%d")
+    expect_equal(
+      validate_import_date(test_strings,  
+                           field_name = "date",
+                           field_min = NA, 
+                           field_max = NA, 
+                           logfile = ""), 
+      compare_string
+    )
+  }
+)
+
+test_that(
+  "NA passes without a message", 
+  {
+    expect_equal(
+      validate_import_date(c("2023-01-01", NA),  
+                           field_name = "date",
+                           field_min = NA, 
+                           field_max = NA, 
+                           logfile = ""), 
+      c("2023-01-01", NA)
+    )
+  }
+)
+
+test_that(
+  "Unmappable values return a message", 
+  {
+    expect_message(
+      validate_import_date(c("2023-01-33", "not a date"), 
+                           field_name = "date",
+                           field_min = NA, 
+                           field_max = NA, 
+                           logfile = ""), 
+      "must have POSIXct class, Date class, or character class in ymd, mdy, or dmy format"
+    )
+  }
+)
+
+test_that(
+  "When a date is less than field_min, a message is returned", 
+  {
+    expect_message(
+      validate_import_date(as.Date(c("2023-01-01", "2023-03-01")), 
+                           field_name = "date", 
+                           field_min = as.Date("2023-02-01"), 
+                           field_max = NA, 
+                           logfile = ""), 
+      "before the stated minimum date"
+    )
+  }
+)
+
+test_that(
+  "When a date is greater than field_max, a message is returned", 
+  {
+    expect_message(
+      validate_import_date(as.Date(c("2023-01-01", "2023-03-01")), 
+                           field_name = "date", 
+                           field_min = NA, 
+                           field_max = as.Date("2023-02-01"), 
+                           logfile = ""), 
+      "after the stated maximum date"
+    )
+  }
+)
+
+# validate_import_datetime ------------------------------------------
+test_that(
+  "Date values are converted to YYYY-mm-dd format", 
+  {
+    date_test <- Sys.Date()
+    expect_equal(
+      validate_import_datetime(date_test,  
+                               field_name = "datetime",
+                               field_min = NA, 
+                               field_max = NA, 
+                               logfile = ""),
+      format(date_test, "%Y-%m-%d %H:%M")
+    )
+  }
+)
+
+test_that(
+  "POSIXct values are converted to YYYY-mm-dd format", 
+  {
+    datetime_test <- Sys.time()
+    expect_equal(
+      validate_import_datetime(datetime_test,  
+                               field_name = "datetime",
+                               field_min = NA, 
+                               field_max = NA, 
+                               logfile = ""),
+      format(datetime_test, "%Y-%m-%d %H:%M")
+    )
+  }
+)
+
+test_that(
+  "ymd, ymd HMS map to YYYY-mm-dd format",
+  {
+    test_strings <- c("2023-01-01", "2023-01-02 03:04:05")
+    
+    compare_string <- as.POSIXct(c("2023-01-01 00:00:00", 
+                                   "2023-01-02 03:04:05"), 
+                                 tz = "UTC")
+    compare_string <- format(compare_string, 
+                             format = "%Y-%m-%d %H:%M")
+    expect_equal(
+      validate_import_datetime(test_strings,  
+                               field_name = "datetime",
+                               field_min = NA, 
+                               field_max = NA, 
+                               logfile = ""), 
+      compare_string
+    )
+  }
+)
+
+test_that(
+  "mdy, mdy HMS YYYY-mm-dd format",
+  {
+    test_strings <- c("01-01-2023", "01-02-2023 03:04:05")
+    
+    compare_string <- as.POSIXct(c("2023-01-01 00:00:00", "2023-01-02 03:04:05"))
+    compare_string <- format(compare_string, 
+                             format = "%Y-%m-%d %H:%M")
+    expect_equal(
+      validate_import_datetime(test_strings,  
+                               field_name = "datetime",
+                               field_min = NA, 
+                               field_max = NA, 
+                               logfile = ""), 
+      compare_string
+    )
+  }
+)
+
+test_that(
+  "dmy, dmy HMS YYYY-mm-dd format",
+  {
+    test_strings <- c("13-01-2023", "01-01-2023 03:04:05")
+    
+    compare_string <- as.POSIXct(c("2023-01-13 00:00:00", 
+                                   "2023-01-01 03:04:05"), 
+                                 tz = "UTC")
+    compare_string <- format(compare_string, 
+                             format = "%Y-%m-%d %H:%M")
+    expect_equal(
+      validate_import_datetime(test_strings,  
+                               field_name = "datetime",
+                               field_min = NA, 
+                               field_max = NA, 
+                               logfile = ""), 
+      compare_string
+    )
+  }
+)
+
+test_that(
+  "NA passes without a message", 
+  {
+    expect_equal(
+      validate_import_datetime(c("2023-01-01", NA),  
+                               field_name = "datetime",
+                               field_min = NA, 
+                               field_max = NA, 
+                               logfile = ""), 
+      c("2023-01-01 00:00", NA)
+    )
+  }
+)
+
+test_that(
+  "Unmappable values return a message", 
+  {
+    expect_message(
+      validate_import_datetime(c("2023-01-33", "not a date"), 
+                               field_name = "datetime",
+                               field_min = NA, 
+                               field_max = NA, 
+                               logfile = ""), 
+      "must have POSIXct class, Date class, or character class in ymd, mdy, or dmy format"
+    )
+  }
+)
+
+test_that(
+  "When a date is less than field_min, a message is returned", 
+  {
+    expect_message(
+      validate_import_datetime(as.POSIXct(c("2023-01-01", "2023-03-01")), 
+                               field_name = "date", 
+                               field_min = as.POSIXct("2023-02-01 00:00:00"), 
+                               field_max = NA, 
+                               logfile = ""), 
+      "before the stated minimum date"
+    )
+  }
+)
+
+test_that(
+  "When a date is greater than field_max, a message is returned", 
+  {
+    expect_message(
+      validate_import_datetime(as.Date(c("2023-01-01", "2023-03-01")), 
+                               field_name = "date", 
+                               field_min = NA, 
+                               field_max = as.POSIXct("2023-02-01"), 
+                               logfile = ""), 
+      "after the stated maximum date"
+    )
+  }
+)
+
+# validate_import_datetime seconds ----------------------------------
+test_that(
+  "Date values are converted to YYYY-mm-dd format", 
+  {
+    date_test <- Sys.Date()
+    expect_equal(
+      validate_import_datetime_seconds(date_test,  
+                                       field_name = "datetime",
+                                       field_min = NA, 
+                                       field_max = NA, 
+                                       logfile = ""),
+      format(date_test, "%Y-%m-%d %H:%M:%S")
+    )
+  }
+)
+
+test_that(
+  "POSIXct values are converted to YYYY-mm-dd format", 
+  {
+    datetime_test <- Sys.time()
+    expect_equal(
+      validate_import_datetime_seconds(datetime_test,  
+                                       field_name = "datetime",
+                                       field_min = NA, 
+                                       field_max = NA, 
+                                       logfile = ""),
+      format(datetime_test, "%Y-%m-%d %H:%M:%S")
+    )
+  }
+)
+
+test_that(
+  "ymd, ymd HMS map to YYYY-mm-dd format",
+  {
+    test_strings <- c("2023-01-01", "2023-01-02 03:04:05")
+    
+    compare_string <- as.POSIXct(c("2023-01-01 00:00:00", 
+                                   "2023-01-02 03:04:05"), 
+                                 tz = "UTC")
+    compare_string <- format(compare_string, 
+                             format = "%Y-%m-%d %H:%M:%S")
+    expect_equal(
+      validate_import_datetime_seconds(test_strings,  
+                                       field_name = "datetime",
+                                       field_min = NA, 
+                                       field_max = NA, 
+                                       logfile = ""), 
+      compare_string
+    )
+  }
+)
+
+test_that(
+  "mdy, mdy HMS YYYY-mm-dd format",
+  {
+    test_strings <- c("01-01-2023", "01-02-2023 03:04:05")
+    
+    compare_string <- as.POSIXct(c("2023-01-01 00:00:00", "2023-01-02 03:04:05"))
+    compare_string <- format(compare_string, 
+                             format = "%Y-%m-%d %H:%M:%S")
+    expect_equal(
+      validate_import_datetime_seconds(test_strings,  
+                                       field_name = "datetime",
+                                       field_min = NA, 
+                                       field_max = NA, 
+                                       logfile = ""), 
+      compare_string
+    )
+  }
+)
+
+test_that(
+  "dmy, dmy HMS YYYY-mm-dd format",
+  {
+    test_strings <- c("13-01-2023", "01-01-2023 03:04:05")
+    
+    compare_string <- as.POSIXct(c("2023-01-13 00:00:00", 
+                                   "2023-01-01 03:04:05"), 
+                                 tz = "UTC")
+    compare_string <- format(compare_string, 
+                             format = "%Y-%m-%d %H:%M:%S")
+    expect_equal(
+      validate_import_datetime_seconds(test_strings,  
+                                       field_name = "datetime",
+                                       field_min = NA, 
+                                       field_max = NA, 
+                                       logfile = ""), 
+      compare_string
+    )
+  }
+)
+
+test_that(
+  "NA passes without a message", 
+  {
+    expect_equal(
+      validate_import_datetime_seconds(c("2023-01-01", NA),  
+                                       field_name = "datetime",
+                                       field_min = NA, 
+                                       field_max = NA, 
+                                       logfile = ""), 
+      c("2023-01-01 00:00:00", NA)
+    )
+  }
+)
+
+test_that(
+  "Unmappable values return a message", 
+  {
+    expect_message(
+      validate_import_datetime_seconds(c("2023-01-33", "not a date"), 
+                                       field_name = "datetime",
+                                       field_min = NA, 
+                                       field_max = NA, 
+                                       logfile = ""), 
+      "must have POSIXct class, Date class, or character class in ymd, mdy, or dmy format"
+    )
+  }
+)
+
+test_that(
+  "When a date is less than field_min, a message is returned", 
+  {
+    expect_message(
+      validate_import_datetime_seconds(as.POSIXct(c("2023-01-01", "2023-03-01")), 
+                                       field_name = "date", 
+                                       field_min = as.POSIXct("2023-02-01 00:00:00"), 
+                                       field_max = NA, 
+                                       logfile = ""), 
+      "before the stated minimum date"
+    )
+  }
+)
+
+test_that(
+  "When a date is greater than field_max, a message is returned", 
+  {
+    expect_message(
+      validate_import_datetime_seconds(as.Date(c("2023-01-01", "2023-03-01")), 
+                                       field_name = "date", 
+                                       field_min = NA, 
+                                       field_max = as.POSIXct("2023-02-01"), 
+                                       logfile = ""), 
+      "after the stated maximum date"
+    )
+  }
+)


### PR DESCRIPTION
There is a touch of scope creep in here. I was writing tests on all of the validations to see if we had any other noise coming. In a few instances, I found places where the validations weren't work as I would expect or intend (itemized below)

I did not write tests for the checkbox validation. I will do that under #18 

Some observations I made but elected not to do anything with are

1. when validating times, should a leading zero be optional?  (i.e. is 6:15 acceptable). 
2. with times, it is only looking at two digits. Not all digits are acceptable. Should we be limiting these to valid times? (0-24:0-60:0-60) As it stands, we would recognize 31:72:89 as a valid time.
3. yes/no only accepts no, yes, 0, and 1. Should it also permit TRUE/FALSE? (for comparison, the validation for truefalse does permit yes/no values)



**Changes made beyond the scope of the issue description:**

If any of these are too far out of scope and you would like them removed, let me know and I can revert. 

1. `validate_import_form_complete`, values that are not 0, 1, or 2, are converted to NA (to prevent an attempt to write an invalid value)
2. `validate_import_time` when counting minutes, an explicit numeric NA is used. (if all values in a vector are missing, it would return a logical NA, which causes a failure when trying to combine with numeric NA.
3. `validate_import_time_mm_ss` has improved handling of NA values from the user.
4. `validate_import_zipcode` converts invalid ZIP codes to NA (to prevent an attempt to write an invalid value)
5. `validate_import_yesno` converts invalid values to NA (to prevent an attempt to write an invalid value)
6. `validate_import_select_dropdown_radio` values not in the data dictionary are set to NA (to prevent an attempt to write an invalid value)
7. `validate_import_email` adds a check to prevent e-mail addresses with two `@` symbols.
8. `validate_import_phone` was attempting to convert invalid phone numbers to NA using the wrong indexing method. This has been corrected.