### PR TITLE
documentation and tests

### DIFF
--- a/R/importRecords.R
+++ b/R/importRecords.R
@@ -45,6 +45,29 @@
 #'
 #' See the documentation for \code{\link{validateImport}} for detailed
 #' explanations of the validation.
+#' 
+#' @section Limitations:
+#' 
+#' The REDCap API is fairly restrictive about what it will accept as valid data for import. 
+#' \code{importRecords} tries to simplify the process by allowing users to 
+#' submit data in any form recognized by the data dictionary. It is then converted
+#' internally to the 
+#' appropriate text format for import. This means, for example, that a radio button value
+#' where the code \code{1} is mapped to the label \code{Guitar} (defined in the user interface
+#' with "1, Guitar"), the user can provide
+#' either "1" or "Guitar" as a value and \code{importRecords} will translate it to the 
+#' code that the API expects. 
+#' 
+#' While this provides a level of convenience for the user, it has some limitations when
+#' applied to checkbox values. When submitting checkbox values for import, it is strongly 
+#' recommended that you submit either the code "0" (for unchecked), "1" (for checked), or the 
+#' labels "Unchecked" and "Checked". 
+#' 
+#' In particular, when the checkbox labels are defined with a code or label that is "0" or "1"
+#' (for example, "0, checkbox_label" or "check_code, 0"), \code{importRecords} is unable to 
+#' determine if a 0 indicates an unchecked box or if the zero is the label of a checked box. 
+#' When encountering ambiguity, \code{importRecords} will always assume "0" represents an
+#' unchecked box and "1" represents a checked box.
 #'
 #' @author Benjamin Nutter\cr
 #' with thanks to Josh O'Brien and etb (see references)

--- a/R/validateImport_methods.R
+++ b/R/validateImport_methods.R
@@ -402,6 +402,10 @@ validate_import_select_dropdown_radio <- function(x, field_name, field_choice, l
 }
 
 # validate_import_checkbox ------------------------------------------
+# Tests to run
+# * 0, 1, Unchecked, Checked, '', NA all pass.
+# * codes and labels pass
+# * Other values produce a message
 
 validate_import_checkbox <- function(x, field_name, field_choice, logfile)
 {
@@ -411,11 +415,11 @@ validate_import_checkbox <- function(x, field_name, field_choice, logfile)
   checkChoice <- trimws(stringr::str_split_fixed(unlist(strsplit(field_choice, "[|]")), ", ", 2))
   checkChoice <- checkChoice[checkChoice[, 1] == unlist(strsplit(field_name, "___"))[2], ]
   
-  w <- which(!x %in% c("Checked", "Unchecked", "0", "1", checkChoice, "") & !is.na(x))
+  w <- which(!x %in% c("checked", "unchecked", "0", "1", tolower(checkChoice), "", NA))
 
-  x <- gsub("checked", "1", x)
-  x <- gsub("unchecked", "0", x)
-  x[x %in% checkChoice] <- 1
+  x <- gsub("^checked$", "1", x)
+  x <- gsub("^unchecked$", "0", x)
+  x[!x %in% c("0", "1") & x %in% tolower(checkChoice)] <- 1
   x[x == ""] <- 0
   x[!x %in% c("0", "1")] <- NA
   
@@ -423,7 +427,8 @@ validate_import_checkbox <- function(x, field_name, field_choice, logfile)
     field_name,
     indices = w,
     message = paste0("Value(s) must be one of '0', '1', 'Checked', 'Unchecked', '",
-                     checkChoice, "', '' (ignoring case).\n",
+                     paste0(checkChoice, collapse = "', '"), 
+                     "', '' (ignoring case).\n",
                      "Values not imported"),
     logfile = logfile
   )

--- a/man/importRecords.Rd
+++ b/man/importRecords.Rd
@@ -93,6 +93,31 @@ data before attempting the import.  Namely
 See the documentation for \code{\link{validateImport}} for detailed
 explanations of the validation.
 }
+\section{Limitations}{
+
+
+The REDCap API is fairly restrictive about what it will accept as valid data for import. 
+\code{importRecords} tries to simplify the process by allowing users to 
+submit data in any form recognized by the data dictionary. It is then converted
+internally to the 
+appropriate text format for import. This means, for example, that a radio button value
+where the code \code{1} is mapped to the label \code{Guitar} (defined in the user interface
+with "1, Guitar"), the user can provide
+either "1" or "Guitar" as a value and \code{importRecords} will translate it to the 
+code that the API expects. 
+
+While this provides a level of convenience for the user, it has some limitations when
+applied to checkbox values. When submitting checkbox values for import, it is strongly 
+recommended that you submit either the code "0" (for unchecked), "1" (for checked), or the 
+labels "Unchecked" and "Checked". 
+
+In particular, when the checkbox labels are defined with a code or label that is "0" or "1"
+(for example, "0, checkbox_label" or "check_code, 0"), \code{importRecords} is unable to 
+determine if a 0 indicates an unchecked box or if the zero is the label of a checked box. 
+When encountering ambiguity, \code{importRecords} will always assume "0" represents an
+unchecked box and "1" represents a checked box.
+}
+
 \references{
 See the REDCap API documentation at your institution's REDCap documentation.
 }

--- a/tests/testthat/test-validateImport_methods.R
+++ b/tests/testthat/test-validateImport_methods.R
@@ -1,0 +1,102 @@
+# validate_import_checkbox ------------------------------------------
+
+test_that(
+  "0, 1, Unchecked, Checked, '', NA all pass", 
+  {
+    test_checkbox <- c("0", "1", 
+                       "Unchecked", "UNCHECKED", "UnChEcKeD", "unchecked", 
+                       "Checked", "CHECKED", "ChEcKeD", "checked", 
+                       "", NA_character_)
+    check_define <- "check1, Guitar | check2, Lute | check3 , Harp "
+    expect_equal(
+      validate_import_checkbox(test_checkbox, 
+                               field_name = "checkbox___check1", 
+                               field_choice = check_define, 
+                               logfile = ""), 
+      c("0", "1", 
+        "0", "0", "0", "0", 
+        "1", "1", "1", "1", 
+        "0", NA_character_)
+    )
+  }
+)
+
+
+test_that(
+  "0, 1, NA all pass (numeric)", 
+  {
+    test_checkbox <- c(0, 1, NA_real_)
+    check_define <- "check1, Guitar | check2, Lute | check3 , Harp "
+    expect_equal(
+      validate_import_checkbox(test_checkbox, 
+                               field_name = "checkbox___check1", 
+                               field_choice = check_define, 
+                               logfile = ""), 
+      c("0", "1", NA_character_)
+    )
+  }
+)
+
+
+test_that(
+  "codes and labels pass", 
+  {
+    test_checkbox <- c("check1", "Guitar")
+    check_define <- "check1, Guitar | check2, Lute | check3 , Harp "
+    expect_equal(
+      validate_import_checkbox(test_checkbox, 
+                               field_name = "checkbox___check1", 
+                               field_choice = check_define, 
+                               logfile = ""), 
+      c("1", "1")
+    )
+  }
+)
+
+test_that(
+  "codes and labels pass (second option)", 
+  {
+    test_checkbox <- c("check2", "Lute")
+    check_define <- "check1, Guitar | check2, Lute | check3 , Harp "
+    expect_equal(
+      validate_import_checkbox(test_checkbox, 
+                               field_name = "checkbox___check2", 
+                               field_choice = check_define, 
+                               logfile = ""), 
+      c("1", "1")
+    )
+  }
+)
+
+
+test_that(
+  "0 code or 0 label returns 0", 
+  {
+    test_checkbox <- c("0")
+    check_define <- "0, 0 | 1, 1"
+    expect_equal(
+      validate_import_checkbox(test_checkbox, 
+                               field_name = "checkbox___0", 
+                               field_choice = check_define, 
+                               logfile = ""), 
+      c("0")
+    )
+  }
+)
+
+
+test_that(
+  "unmapped values produce a message", 
+  {
+    local_reproducible_output(width = 200)
+    test_checkbox <- c("check_lute")
+    check_define <- "check1, Guitar | check2, Lute | check3 , Harp "
+    expect_message(
+      validate_import_checkbox(test_checkbox, 
+                               field_name = "checkbox___check2", 
+                               field_choice = check_define, 
+                               logfile = ""), 
+      "must be one of '0', '1', 'Checked', 'Unchecked', 'check2', 'Lute', ''"
+    )
+  }
+)


### PR DESCRIPTION
Tests for validation of checkboxes. Minor fixes to validate_import_checkbox to bring it into compliance with expectations definedin tests.

Writing the tests exposed some weaknesses in the validation which have been corrected.

Note that the validate_import_methods file and its accompanying test file are also modified in pull request #19 