### PR TITLE
Tests for most of the remaining export functions

### DIFF
--- a/R/checkbox_suffixes.R
+++ b/R/checkbox_suffixes.R
@@ -16,12 +16,14 @@ checkbox_suffixes <- function(fields, meta_data, version)
 {
   name_suffix <- sapply(X = fields, 
                         FUN = manual_checkbox_suffixes, 
-                        meta_data)
+                        meta_data, 
+                        simplify = FALSE)
 
   label_suffix <- 
     sapply(X = fields,
            FUN = manual_checkbox_label_suffixes,
-           meta_data)
+           meta_data, 
+           simplify = FALSE)
   
   list(name_suffix = unlist(name_suffix),
        label_suffix = unlist(label_suffix))
@@ -59,11 +61,10 @@ manual_checkbox_label_suffixes <- function(x, meta_data)
   if (meta_data$field_type[meta_data$field_name %in% x] == "checkbox"){
     #* Select choices
     opts <- meta_data$select_choices_or_calculations[meta_data$field_name %in% x]
-    #* Remove choice numbers, split, then remove spaces
-    opts <- gsub("\\d,", "", opts)
-    opts <- strsplit(x = opts,
-                     split = "[|]")[[1]]
-    opts <- gsub("(^ *| *$)", "", opts)
+    opts <- strsplit(opts, "[|]")
+    opts <- unlist(opts)
+    opts <- sub("^.*?,", "", opts)
+    opts <- trimws(opts)
     #* Assemble labels
     paste0(meta_data$field_label[meta_data$field_name %in% x], ": ", opts)
   }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,5 +1,4 @@
 library(testthat)
 library(redcapAPI)
 
-
 test_check("redcapAPI")

--- a/tests/testthat/helper-REDCapQACredentials.R
+++ b/tests/testthat/helper-REDCapQACredentials.R
@@ -27,3 +27,5 @@ if(!exists("API_KEY")){
   keyring::keyring_unlock('TestRedcapAPI', password)
   API_KEY <- keyring::key_get('TestRedcapAPI', 'TestRedcapAPI', 'TestRedcapAPI')
 }
+
+library(checkmate) # for additional expect_* functions.

--- a/tests/testthat/test-checkbox_suffixes.R
+++ b/tests/testthat/test-checkbox_suffixes.R
@@ -1,0 +1,39 @@
+context("checkbox_suffixes.R")
+
+rcon <- redcapConnection(url = url, 
+                         token = API_KEY)
+
+CheckboxMetaData <- exportMetaData(rcon)
+CheckboxMetaData <- CheckboxMetaData[CheckboxMetaData$field_name %in% c("prereq_checkbox"), ]
+# For the purpose of testing, we are going to add a couple more options to these meta data
+# Doing it this way allows us to add tests for any code/label mapping without having to 
+# alter the testing database.
+CheckboxMetaData$select_choices_or_calculations <- 
+  paste0(CheckboxMetaData$select_choices_or_calculations, 
+         " | lowercase, Lowercase code | mixedCase, Mixed case code | 12ab, alpha, numeric | use_underscore, Use an underscore")
+
+test_that(
+  "Checkbox suffixes are correctly generated", 
+  {
+    expect_equal(
+      checkbox_suffixes(fields = c("prereq_checkbox"), 
+                        meta_data = CheckboxMetaData), 
+      list(name_suffix = c(prereq_checkbox1 = "prereq_checkbox___1", 
+                           prereq_checkbox2 = "prereq_checkbox___2", 
+                           prereq_checkbox3 = "prereq_checkbox___abc", 
+                           prereq_checkbox4 = "prereq_checkbox___4", 
+                           prereq_checkbox5 = "prereq_checkbox___lowercase", 
+                           prereq_checkbox6 = "prereq_checkbox___mixedcase", 
+                           prereq_checkbox7 = "prereq_checkbox___12ab", 
+                           prereq_checkbox8 = "prereq_checkbox___use_underscore"), 
+           label_suffix = c(prereq_checkbox1 = "Pre-requisite as a checkbox: Checkbox1", 
+                            prereq_checkbox2 = "Pre-requisite as a checkbox: Checkbox2",
+                            prereq_checkbox3 = "Pre-requisite as a checkbox: CheckboxABC", 
+                            prereq_checkbox4 = "Pre-requisite as a checkbox: Do not use in branching logic", 
+                            prereq_checkbox5 = "Pre-requisite as a checkbox: Lowercase code", 
+                            prereq_checkbox6 = "Pre-requisite as a checkbox: Mixed case code", 
+                            prereq_checkbox7 = "Pre-requisite as a checkbox: alpha, numeric", 
+                            prereq_checkbox8 = "Pre-requisite as a checkbox: Use an underscore"))
+    )
+  }
+)

--- a/tests/testthat/test-exportArms.R
+++ b/tests/testthat/test-exportArms.R
@@ -2,6 +2,65 @@ context("exportArms")
 
 rcon <- redcapConnection(url = url, token = API_KEY)
 
-test_that("returns 2 for a project with 2 arms",{
-  expect_equal(length(exportArms(rcon)), 2)
+test_that(
+  "Return an error if rcon is not a redcapConnectionObject", 
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportArms("not an rcon"), 
+                 "no applicable method for 'exportArms'")
+  }
+)
+
+test_that(
+  "Return an error if arms is not a character vector", 
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportArms(rcon, pi), 
+                 "Variable 'arms'[:] Must be of type 'character'")
+  }
+)
+
+
+test_that("Returns a data frame with two rows for a study with two arms",{
+  is_longitudinal <- 
+    as.logical(exportProjectInformation(rcon)$is_longitudinal)
+  
+  skip_if(!is_longitudinal, 
+          "Test project is not a longitudinal project. This test is skipped")
+  
+  expect_data_frame(exportArms(rcon), 
+                    nrows = 2)
 })
+
+
+test_that(
+  "Returns a data frame for specific arms",
+  {
+    is_longitudinal <- 
+      as.logical(exportProjectInformation(rcon)$is_longitudinal)
+    
+    skip_if(TRUE,
+            "Throwing an error when arms is specified. Revisit this test after correcting.")
+    
+    skip_if(!is_longitudinal, 
+            "Test project is not a longitudinal project. This test is skipped")
+    
+    exportArms(rcon, arms = c("1"))
+  }
+)
+
+
+test_that(
+  "Returns NULL for a classic project",
+  {
+    is_longitudinal <- 
+      as.logical(exportProjectInformation(rcon)$is_longitudinal)
+    
+    skip_if(is_longitudinal, 
+            "Test project is a longitudinal project. This test is skipped")
+    
+    expect_null(exportArms(rcon))
+  }
+)
+
+

--- a/tests/testthat/test-exportEvents.R
+++ b/tests/testthat/test-exportEvents.R
@@ -1,0 +1,67 @@
+context("exportEvents.R")
+
+rcon <- redcapConnection(url = url, token = API_KEY)
+
+test_that(
+  "Return an error when rcon is not a redcapConnection object", 
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportEvents("not an rcon"), 
+                 "no applicable method for 'exportEvents'")
+  }
+)
+
+test_that(
+  "Return an error when arms is not character", 
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportEvents(rcon, 
+                              arms = pi), 
+                 "Variable 'arms'[:] Must be of type 'character'")
+  }
+)
+
+test_that(
+  "Returns a data frame of events (Longitudinal project)", 
+  {
+    is_longitudinal <- 
+      as.logical(exportProjectInformation(rcon)$is_longitudinal)
+    
+    skip_if(!is_longitudinal, 
+            "Test project is not a longitudinal project. This test is skipped")
+    
+    expect_data_frame(exportEvents(rcon), 
+                      ncols = 5)
+  }
+)
+
+test_that(
+  "Returns a data frame of events for a specific arms", 
+  {
+    is_longitudinal <- 
+      as.logical(exportProjectInformation(rcon)$is_longitudinal)
+    
+    skip_if(!is_longitudinal, 
+            "Test project is not a longitudinal project. This test is skipped")
+    
+    expect_data_frame(exportEvents(rcon, 
+                                   arms = c("2")), 
+                      ncols = 5, 
+                      nrow = 1)
+      
+  }
+)
+
+
+test_that(
+  "Returns NULL for classical projects", 
+  {
+    is_longitudinal <- 
+      as.logical(exportProjectInformation(rcon)$is_longitudinal)
+    
+    skip_if(is_longitudinal, 
+            "Test project is a longitudinal project. This test is skipped")
+    
+    expect_null(exportEvents(rcon))
+  }
+)

--- a/tests/testthat/test-exportFieldNames.R
+++ b/tests/testthat/test-exportFieldNames.R
@@ -1,0 +1,63 @@
+context("exportFieldsNames.R")
+
+rcon <- redcapConnection(url = url, token = API_KEY)
+
+test_that(
+  "Return an error when rcon is not a redcapConnection object", 
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportFieldNames("not an rcon"), 
+                 "no applicable method for 'exportFieldNames'")
+  }
+)
+
+
+test_that(
+  "Return an error when fields is not character", 
+  {
+    local_reproducible_output(width = 200)
+    expect_error(
+      exportFieldNames(rcon, 
+                       fields = 1:2), 
+      "'fields'[:] Must be of type 'character'"
+    )
+  }
+)
+
+test_that(
+  "Return an error if bundle is not of class redcapBundle",
+  {
+    local_reproducible_output(width = 200)
+    expect_error(
+      exportFieldNames(rcon, 
+                       bundle = "this is not a bundle"), 
+      "Must inherit from class 'redcapBundle'"
+    )
+  }
+)
+
+
+test_that(
+  "Return a data frame when called with defaults",
+  {
+    expect_data_frame(
+      exportFieldNames(rcon),
+      ncols = 3
+    )
+  }
+)
+
+test_that(
+  "Return a data frame with only requested field names", 
+  {
+    skip_if(TRUE, 
+            "Produces a message that claims a bug in the API. It's actually a bug in the package. Revisit this test after this is fixed.")
+    expect_data_frame(
+      exportFieldNames(rcon, 
+                       fields = c("record_id", "prereq_radio", "prereq_checkbox", 
+                                  "treatment", "date_dmy")), 
+      ncols = 3, 
+      nrows = 7
+    )
+  }
+)

--- a/tests/testthat/test-exportInstruments.R
+++ b/tests/testthat/test-exportInstruments.R
@@ -1,0 +1,20 @@
+context("exportInstruments.R")
+
+rcon <- redcapConnection(url = url, token = API_KEY)
+
+test_that(
+  "Return an error when rcon is not a redcapConnection object", 
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportInstruments("not an rcon"), 
+                 "no applicable method for 'exportInstruments'")
+  }
+)
+
+test_that(
+  "Returns a data frame of instruments", 
+  {
+    expect_data_frame(exportInstruments(rcon), 
+                      ncols = 2)
+  }
+)

--- a/tests/testthat/test-exportMappings.R
+++ b/tests/testthat/test-exportMappings.R
@@ -1,0 +1,50 @@
+context("exportMappings.R")
+
+rcon <- redcapConnection(url = url, token = API_KEY)
+
+test_that(
+  "Return an error when rcon is not a redcapConnection object", 
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportMappings("not an rcon"), 
+                 "no applicable method for 'exportMappings'")
+  }
+)
+
+test_that(
+  "Return an error when arms is not character",
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportMappings(rcon, 
+                                arms = 1:2), 
+                 "Variable 'arms'[:] Must be of type 'character'")
+  }
+)
+
+
+test_that(
+  "Return a data frame of mappings when called with defaults (longitudinal)", 
+  {
+    is_longitudinal <- 
+      as.logical(exportProjectInformation(rcon)$is_longitudinal)
+    
+    skip_if(!is_longitudinal, 
+            "Test project is not a longitudinal project. This test is skipped")
+    
+    expect_data_frame(exportMappings(rcon), 
+                      ncols = 3)
+  }
+)
+
+test_that(
+  "Return NULL for a classial project", 
+  {
+    is_longitudinal <- 
+      as.logical(exportProjectInformation(rcon)$is_longitudinal)
+    
+    skip_if(is_longitudinal, 
+            "Test project is a longitudinal project. This test is skipped")
+    
+    expect_null(exportMappings(rcon))
+  }
+)

--- a/tests/testthat/test-exportMetaData.R
+++ b/tests/testthat/test-exportMetaData.R
@@ -1,0 +1,68 @@
+context("exportMetaData.R")
+
+rcon <- redcapConnection(url = url, token = API_KEY)
+
+test_that(
+  "Return an error when rcon is not a redcapConnection", 
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportMetaData("not an rcon"), 
+                 "no applicable method for 'exportMetaData'")
+  }
+)
+
+test_that(
+  "Return an error when fields is not character", 
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportMetaData(rcon, fields = 1:3), 
+                 "'fields'[:] Must be of type 'character'")
+  }
+)
+
+test_that(
+  "Return an error when forms is not character", 
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportMetaData(rcon, forms = 1:3), 
+                 "'forms'[:] Must be of type 'character'")
+  }
+)
+
+
+test_that(
+  "Return a data frame when called with defaults", 
+  {
+    expect_data_frame(exportMetaData(rcon), 
+                      ncols = 18)
+  }
+)
+
+test_that(
+  "Return a data frame of only selected fields", 
+  {
+    skip_if (TRUE, 
+             "exportMetaData is not responding to the fields argument. Review this test after correcting.")
+    expect_data_frame(
+      exportMetaData(rcon, 
+                     fields = c("record_id", "date_dmy", "prereq_radio")), 
+      ncols = 18, 
+      nrows = 3
+    )
+  }
+)
+
+test_that(
+  "Return a data frame of only selected forms", 
+  {
+    skip_if (TRUE, 
+             "exportMetaData is not responding to the forms argument. Review this test after correcting.")
+    expect_data_frame(
+      exportMetaData(rcon, 
+                     forms = c("fieldtovar_datetimes", "randomization")), 
+      ncols = 18, 
+      nrows = 14
+    )
+  }
+)
+

--- a/tests/testthat/test-exportNextRecordName.R
+++ b/tests/testthat/test-exportNextRecordName.R
@@ -1,0 +1,25 @@
+context("exportNextRecordName.R")
+
+rcon <- redcapConnection(url = url, token = API_KEY)
+
+test_that(
+  "Return an error if rcon is not a redcapConnection", 
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportNextRecordName("not an rcon"), 
+                 "no applicable method for 'exportNextRecordName'")
+  }
+)
+
+test_that(
+  "Return the next record name", 
+  {
+    Records <- exportRecords(rcon, 
+                             fields = "record_id")
+    next_id <- max(as.numeric(Records$record_id)) + 1
+    # Since the test data base can be expected to 
+    expect_equal(exportNextRecordName(rcon), 
+                 next_id)
+  }
+)
+

--- a/tests/testthat/test-exportProjectInformation.R
+++ b/tests/testthat/test-exportProjectInformation.R
@@ -1,0 +1,23 @@
+context("exportProjectInformation.R")
+
+rcon <- redcapConnection(url = url, token = API_KEY)
+
+test_that(
+  "Return an error if rcon is not a redcapConnection", 
+  {
+    expect_error(exportProjectInformation("not an rcon"), 
+                 "no applicable method for 'exportProjectInformation'")
+  }
+)
+
+test_that(
+  "Return a data frame with 1 row", 
+  {
+    # If this suddenly starts failing, look to see if the API has 
+    # added more columns. Hard coding the number of columns in the 
+    # test may be a bit of a fool's move (sorry).
+    expect_data_frame(exportProjectInformation(rcon), 
+                      ncols = 26,
+                      nrows = 1)
+  }
+)

--- a/tests/testthat/test-exportRecords.R
+++ b/tests/testthat/test-exportRecords.R
@@ -6,3 +6,231 @@ test_that("records can be exported",{
   expect_silent(rec <- exportRecords(rcon))
   expect_gte(length(rec), 1)
 })
+
+#!! for tests regarding variable conversions, see test-fieldToVar.R
+
+
+# Tests for fields, forms, records ----------------------------------
+test_that(
+  "Records returned for designated fields", 
+  {
+    fields_to_get <- c("record_id", 
+                       "date_ymd", 
+                       "prereq_number")
+    Records <- exportRecords(rcon, 
+                             fields = fields_to_get)
+    expect_subset(fields_to_get, 
+                  choices = names(Records))
+  }
+)
+
+test_that(
+  "fields in the designated forms are returned", 
+  {
+    forms_to_get <- c("fieldtovar_datetimes", 
+                      "branching_logic")
+    Records <- exportRecords(rcon, 
+                             forms = forms_to_get)
+    expect_false("treatment" %in% names(Records))
+  }
+)
+
+test_that(
+  "records returned only for designated records", 
+  {
+    records_to_get <- 1:3
+    Records <- exportRecords(rcon, 
+                             records = records_to_get)
+    expect_true(all(Records$record_id %in% records_to_get))
+  }
+)
+
+test_that(
+  "Data returned only for designated event", 
+  {
+    Records <- exportRecords(rcon, 
+                             events = "event_1_arm_1")
+    expect_true(all(Records$redcap_event_name %in% "event_1_arm_1"))
+  }
+)
+
+
+# Argument validation tests -----------------------------------------
+
+test_that(
+  "Return an error if rcon is not a redcapConnection", 
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportRecords("not an rcon"), 
+                 "no applicable method for 'exportRecords'")
+  }
+)
+
+test_that(
+  "Return an error if factors is not logical(1)", 
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportRecords(rcon, 
+                               factors = c(TRUE, FALSE)), 
+                 "'factors'[:] Must have length 1")
+    expect_error(exportRecords(rcon, factors = "TRUE"), 
+                 "Variable 'factors'[:] Must be of type 'logical'")
+  }
+)
+
+test_that(
+  "Return an error if fields is not character", 
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportRecords(rcon, 
+                               fields = 1:2), 
+                 "'fields'[:] Must be of type 'character'")
+  }
+)
+
+test_that(
+  "Return an error if forms is not character", 
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportRecords(rcon, 
+                               fields = 1:2), 
+                 "'fields'[:] Must be of type 'character'")
+  }
+)
+
+
+test_that(
+  "Return an error if records is not numeric or character", 
+  {
+    local_reproducible_output(width = 200)
+    WithCharacter <- exportRecords(rcon, records = c("1", "2"))
+    WithNumeric <- exportRecords(rcon, records = c(1, 2))
+    
+    expect_identical(WithCharacter, 
+                     WithNumeric)
+    expect_error(exportRecords(rcon, records = TRUE), 
+                 "'records'[:] Must be of type 'character'")
+  } 
+)
+
+test_that(
+  "Return an error if events is not character", 
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportRecords(rcon, events = 1), 
+                 "'events'[:] Must be of type 'character'")
+  }
+)
+
+test_that(
+  "Return an error if labels is not logical(1)", 
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportRecords(rcon, 
+                               labels = c(TRUE, FALSE)), 
+                 "'labels'[:] Must have length 1")
+    expect_error(exportRecords(rcon, 
+                               labels = "TRUE"), 
+                 "'labels'[:] Must be of type 'logical'")
+  }
+)
+
+test_that(
+  "Return an error if dates is not logical(1)",
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportRecords(rcon, 
+                               dates = c(TRUE, FALSE)), 
+                 "'dates'[:] Must have length 1")
+    expect_error(exportRecords(rcon, 
+                               dates = "TRUE"), 
+                 "'dates'[:] Must be of type 'logical'")
+  }
+)
+
+test_that(
+  "Return an error if survey is not logical(1)",
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportRecords(rcon, 
+                               survey = c(TRUE, FALSE)), 
+                 "'survey'[:] Must have length 1")
+    expect_error(exportRecords(rcon, 
+                               survey = "TRUE"), 
+                 "'survey'[:] Must be of type 'logical'")
+  }
+)
+
+test_that(
+  "Return an error if dag is not logical(1)",
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportRecords(rcon, 
+                               dag = c(TRUE, FALSE)), 
+                 "'dag'[:] Must have length 1")
+    expect_error(exportRecords(rcon, 
+                               dag = "TRUE"), 
+                 "'dag'[:] Must be of type 'logical'")
+  }
+)
+
+test_that(
+  "Return an error if checkboxLabels is not logical(1)",
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportRecords(rcon, 
+                               checkboxLabels = c(TRUE, FALSE)), 
+                 "'checkboxLabels'[:] Must have length 1")
+    expect_error(exportRecords(rcon, 
+                               checkboxLabels = "TRUE"), 
+                 "'checkboxLabels'[:] Must be of type 'logical'")
+  }
+)
+
+test_that(
+  "Return an error if colClasses is not a named vector", 
+  {
+    local_reproducible_output(width = 200)
+    skip_if(TRUE, 
+            paste("Documentation claims that this is the expected type.", 
+                  "There is not argument validation, however.", 
+                  "A named list should also be acceptable"))
+  }
+)
+
+test_that(
+  "Return an error if batch.size is not integerish(1)", 
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportRecords(rcon, 
+                               batch.size = c(-1, 100)), 
+                 "'batch.size'[:] Must have length 1")
+    expect_error(exportRecords(rcon, 
+                               batch.size = "-1"), 
+                 "'batch.size'[:] Must be of type 'integerish'")
+  }
+)
+
+test_that(
+  "Return an error if bundle is not a redcapBundle object", 
+  {
+    local_reproducible_output(width = 200)
+    skip_if(TRUE, 
+            "There is no argument validation on bundle. Address this test after fixing.")
+    expect_error(exportRecords(rcon, 
+                               bundle = "not a bundle"))
+  }
+)
+
+test_that(
+  "Return an error if form_complete_auto is not logical(1)", 
+  {
+    local_reproducible_output(width = 200)
+    expect_error(exportRecords(rcon, 
+                               form_complete_auto = c(TRUE, FALSE)), 
+                 "'form_complete_auto'[:] Must have length 1")
+    expect_error(exportRecords(rcon, 
+                               form_complete_auto = "TRUE"), 
+                 "'form_complete_auto'[:] Must be of type 'logical'")
+  }
+)

--- a/tests/testthat/test-exportUsers.R
+++ b/tests/testthat/test-exportUsers.R
@@ -1,0 +1,73 @@
+context("exportUsers.R")
+
+rcon <- redcapConnection(url = url, token = API_KEY)
+
+test_that(
+  "Return an error if rcon is not a redcapConnection", 
+  {
+    expect_error(exportUsers("not an rcon"), 
+                 "no applicable method for 'exportUsers'")
+  }
+)
+
+test_that(
+  "Return an error if dates is not logical(1)", 
+  {
+    expect_error(exportUsers(rcon, 
+                             dates = c(TRUE, FALSE)), 
+                 "'dates'[:] Must have length 1")
+    expect_error(exportUsers(rcon, 
+                             dates = "TRUE"), 
+                 "'dates'[:] Must be of type 'logical'")
+  }
+)
+
+
+test_that(
+  "Return an error if labels is not logical(1)", 
+  {
+    expect_error(exportUsers(rcon, 
+                             labels = c(TRUE, FALSE)), 
+                 "'labels'[:] Must have length 1")
+    expect_error(exportUsers(rcon, 
+                             labels = "TRUE"), 
+                 "'labels'[:] Must be of type 'logical'")
+  }
+)
+
+test_that(
+  "Return an error if bundle is not a redcapBundle", 
+  {
+    expect_error(exportUsers(rcon, 
+                             bundle = "not a bundle"), 
+                 "'bundle'[:] Must inherit from class 'redcapBundle'")
+  }
+)
+
+
+test_that(
+  "Returns a data frame when called with defaults", 
+  {
+    skip_if(TRUE, 
+            "There is an error when labels = TRUE. Revisit this test when corrected.")
+    expect_data_frame(exportUsers(rcon))
+  }
+)
+
+test_that(
+  "Returns a data frame with dates = FALSE", 
+  {
+    expect_data_frame(exportUsers(rcon, 
+                                  dates = FALSE, 
+                                  labels = FALSE))
+  }
+)
+
+test_that(
+  "Returns a data frame with labels = FALSE", 
+  {
+    expect_data_frame(exportUsers(rcon,  
+                                  labels = FALSE))
+  }
+)
+

--- a/tests/testthat/test-exportVersion.R
+++ b/tests/testthat/test-exportVersion.R
@@ -1,0 +1,19 @@
+context("exportVersion.R")
+
+rcon <- redcapConnection(url = url, token = API_KEY)
+
+test_that(
+  "Return an error if rcon is not a redcapConnection", 
+  {
+    expect_error(exportVersion("not an rcon"), 
+                 "no applicable method for 'exportVersion'")
+  }
+)
+
+test_that(
+  "exportVersion returns a version number", 
+  {
+    expect_silent(version <- exportVersion(rcon))
+    expect_true(grepl("\\d{1,4}[.]\\d{1,4}[.]\\d{1,4}", version))
+  }
+)


### PR DESCRIPTION
It's unsolicited, but you didn't tell me "no" :) 

I haven't worked on exportBundle, exportFiles, exportPdf, exportRecords_offline, or exportRecords.

In most cases, I figured it would be better to write those tests after making a space in the test project to test those features.

There is one file modified that isn't a testing file. While writing tests for checkbox_suffix, I found some flaws in how the checkbox labels were being extracted.  I felt the change was small enough to warrant slipping in.