### PR TITLE
Bstatgen 1094 drop arg

### DIFF
--- a/R/exportRecords.R
+++ b/R/exportRecords.R
@@ -28,7 +28,7 @@
 #' @param survey specifies whether or not to export the survey identifier field 
 #'   (e.g., "redcap_survey_identifier") or survey timestamp fields 
 #'   (e.g., form_name+"_timestamp") when surveys are utilized in the project. 
-#'   If you do not pass in this flag, it will default to "false". If set to 
+#'   If you do not pass in this flag, it will default to "true". If set to 
 #'   "true", it will return the redcap_survey_identifier field and also the 
 #'   survey timestamp field for a particular survey when at least 
 #'   one field from that survey is being exported. NOTE: If the survey 

--- a/R/exportRecords.R
+++ b/R/exportRecords.R
@@ -378,10 +378,7 @@ exportRecords.redcapApiConnection <-
   
   # drop
   if(length(drop)) {
-    todrop <- intersect(names(x), drop)
-    if(length(todrop)) {
-      x <- x[,!names(x) %in% todrop]
-    }
+    x <- x[,!names(x) %in% drop]
   } # end drop
   
   x

--- a/R/exportRecords.R
+++ b/R/exportRecords.R
@@ -65,7 +65,9 @@
 #'   be retrieved.  When \code{FALSE}, these fields must be 
 #'   explicitly requested.
 #' @param meta_data Deprecated version of \code{metaDataFile}
-#' 
+#' @param drop An optional character vector of REDCap variable names to remove from the 
+#'   dataset; defaults to NULL. E.g., \code{drop=c("date_dmy", "treatment")} 
+#'   It is OK for drop to contain variables not present; these names are ignored.
 #' @details
 #' A record of exports through the API is recorded in the Logging section 
 #' of the project.
@@ -151,7 +153,7 @@
 
 exportRecords <-
   function(rcon, factors = TRUE, fields = NULL, forms = NULL, records = NULL,
-           events = NULL, labels = TRUE, dates = TRUE,
+           events = NULL, labels = TRUE, dates = TRUE, drop = NULL,
            survey = TRUE, dag = TRUE, checkboxLabels = FALSE, 
            colClasses = character(0), ...)
     
@@ -162,7 +164,7 @@ exportRecords <-
 #' 
 exportRecords.redcapDbConnection <- 
   function(rcon, factors = TRUE, fields = NULL, forms = NULL, records = NULL,
-           events = NULL, labels = TRUE, dates = TRUE,
+           events = NULL, labels = TRUE, dates = TRUE, drop = NULL,
            survey = TRUE, dag = TRUE, checkboxLabels = FALSE, 
            colClasses = character(0), ...)
   {
@@ -175,7 +177,7 @@ exportRecords.redcapDbConnection <-
 
 exportRecords.redcapApiConnection <- 
   function(rcon, factors = TRUE, fields = NULL, forms = NULL,
-           records = NULL, events = NULL, labels = TRUE, dates = TRUE,
+           records = NULL, events = NULL, labels = TRUE, dates = TRUE, drop = NULL,
            survey = TRUE, dag = TRUE, checkboxLabels = FALSE,
            colClasses = character(0), ...,
            batch.size = -1,
@@ -372,6 +374,16 @@ exportRecords.redcapApiConnection <-
              SIMPLIFY = FALSE)
   }
 
+  
+  
+  # drop
+  if(length(drop)) {
+    todrop <- intersect(names(x), drop)
+    if(length(todrop)) {
+      x <- x[,!names(x) %in% todrop]
+    }
+  } # end drop
+  
   x
 }
 

--- a/R/exportRecords_offline.R
+++ b/R/exportRecords_offline.R
@@ -126,10 +126,7 @@ exportRecords_offline <- function(dataFile, metaDataFile,
   
   # drop
   if(length(drop)) {
-    todrop <- intersect(names(x), drop)
-    if(length(todrop)) {
-      x <- x[,!names(x) %in% todrop]
-    }
+    x <- x[,!names(x) %in% drop]
   } # end drop
   
   x  

--- a/R/exportRecords_offline.R
+++ b/R/exportRecords_offline.R
@@ -3,7 +3,7 @@
 
 exportRecords_offline <- function(dataFile, metaDataFile, 
                                   factors = TRUE, fields = NULL,
-                                  forms=NULL, labels = TRUE,
+                                  forms=NULL, labels = TRUE, drop = NULL,
                                   dates = TRUE, checkboxLabels = FALSE, 
                                   colClasses = NA,
                                   ..., meta_data)
@@ -122,5 +122,15 @@ exportRecords_offline <- function(dataFile, metaDataFile,
              },
              SIMPLIFY = FALSE)
   }
+  
+  
+  # drop
+  if(length(drop)) {
+    todrop <- intersect(names(x), drop)
+    if(length(todrop)) {
+      x <- x[,!names(x) %in% todrop]
+    }
+  } # end drop
+  
   x  
 }

--- a/R/exportReports.R
+++ b/R/exportReports.R
@@ -177,10 +177,7 @@ exportReports.redcapApiConnection <- function(rcon, report_id, factors = TRUE, l
   
   # drop
   if(length(drop)) {
-    todrop <- intersect(names(x), drop)
-    if(length(todrop)) {
-      x <- x[,!names(x) %in% todrop]
-    }
+    x <- x[,!names(x) %in% drop]
   } # end drop
   
   x 

--- a/R/exportReports.R
+++ b/R/exportReports.R
@@ -16,6 +16,9 @@
 #'   is the label assigned to the level in the data dictionary. This option 
 #'   is only available after REDCap version 6.0.
 #' @param bundle A \code{redcapBundle} object as created by \code{exportBundle}.
+#' @param drop An optional character vector of REDCap variable names to remove from the 
+#'   dataset; defaults to NULL. E.g., \code{drop=c("date_dmy", "treatment")} 
+#'   It is OK for drop to contain variables not present; these names are ignored.
 #' @param ... Additional arguments to be passed between methods.
 #' @param error_handling An option for how to handle errors returned by the API.
 #'   see \code{\link{redcap_error}}
@@ -50,14 +53,14 @@
 #' @export
 
 exportReports <- function(rcon, report_id, factors=TRUE, labels=TRUE, 
-                          dates=TRUE, checkboxLabels=FALSE, ...)
+                          dates=TRUE, drop=NULL, checkboxLabels=FALSE, ...)
   UseMethod("exportReports")
 
 #' @rdname exportReports
 #' @export
 
 exportReports.redcapDbConnection <- function(rcon, report_id, factors=TRUE, labels=TRUE, 
-                                             dates=TRUE, checkboxLabels=FALSE, ...){
+                                             dates=TRUE, drop=NULL, checkboxLabels=FALSE, ...){
   message("Please accept my apologies.  The exportMappings method for redcapDbConnection objects\n",
           "has not yet been written.  Please consider using the API.")          
 }
@@ -66,7 +69,7 @@ exportReports.redcapDbConnection <- function(rcon, report_id, factors=TRUE, labe
 #' @export
 
 exportReports.redcapApiConnection <- function(rcon, report_id, factors = TRUE, labels = TRUE, 
-                                              dates = TRUE, checkboxLabels = FALSE, ...,
+                                              dates = TRUE, drop = NULL, checkboxLabels = FALSE, ...,
                                               bundle = getOption("redcap_bundle"),
                                               error_handling = getOption("redcap_error_handling")){
   
@@ -171,6 +174,14 @@ exportReports.redcapApiConnection <- function(rcon, report_id, factors = TRUE, l
              },
              SIMPLIFY = FALSE)
   }
+  
+  # drop
+  if(length(drop)) {
+    todrop <- intersect(names(x), drop)
+    if(length(todrop)) {
+      x <- x[,!names(x) %in% todrop]
+    }
+  } # end drop
   
   x 
   

--- a/R/fieldToVar.R
+++ b/R/fieldToVar.R
@@ -23,8 +23,6 @@
 #'   checkbox, and form_complete.
 #' @param mChoice logical; defaults to TRUE. Convert checkboxes to mChoice if
 #'   Hmisc is installed.
-#' @param drop An optional character vector of REDCap variable names to remove from the 
-#'   dataset; defaults to NULL. E.g., \code{drop=c("date_dmy", "treatment")}
 #' @param ..., additional arguments that are ignored. 
 #'   
 #' @details This function is called internally by \code{exportRecords} and 
@@ -39,7 +37,6 @@ fieldToVar <- function(records,
                        labels         = TRUE,
                        handlers       =list(),
                        mChoice        = NULL,
-                       drop           = NULL,
                        ...)
 { 
   records_raw <- records
@@ -234,15 +231,6 @@ fieldToVar <- function(records,
     }
 
   } # mChoice 
-  
-  
-  # drop
-  if(length(drop)) {
-    todrop <- intersect(names(records), drop)
-    if(length(todrop)) {
-      records[,!names(records) %in% todrop]
-    }
-  } # end drop
   
   records
 }    

--- a/R/fieldToVar.R
+++ b/R/fieldToVar.R
@@ -23,6 +23,8 @@
 #'   checkbox, and form_complete.
 #' @param mChoice logical; defaults to TRUE. Convert checkboxes to mChoice if
 #'   Hmisc is installed.
+#' @param drop An optional character vector of REDCap variable names to remove from the 
+#'   dataset; defaults to NULL. E.g., \code{drop=c("date_dmy", "treatment")}
 #' @param ..., additional arguments that are ignored. 
 #'   
 #' @details This function is called internally by \code{exportRecords} and 
@@ -35,8 +37,9 @@ fieldToVar <- function(records,
                        dates          = TRUE,
                        checkboxLabels = FALSE,
                        labels         = TRUE,
-                       handlers=list(),
+                       handlers       =list(),
                        mChoice        = NULL,
+                       drop           = NULL,
                        ...)
 { 
   records_raw <- records
@@ -231,6 +234,15 @@ fieldToVar <- function(records,
     }
 
   } # mChoice 
+  
+  
+  # drop
+  if(length(drop)) {
+    todrop <- intersect(names(records), drop)
+    if(length(todrop)) {
+      records[,!names(records) %in% todrop]
+    }
+  } # end drop
   
   records
 }    

--- a/man/exportRecords.Rd
+++ b/man/exportRecords.Rd
@@ -16,6 +16,7 @@ exportRecords(
   events = NULL,
   labels = TRUE,
   dates = TRUE,
+  drop = NULL,
   survey = TRUE,
   dag = TRUE,
   checkboxLabels = FALSE,
@@ -32,6 +33,7 @@ exportRecords(
   events = NULL,
   labels = TRUE,
   dates = TRUE,
+  drop = NULL,
   survey = TRUE,
   dag = TRUE,
   checkboxLabels = FALSE,
@@ -48,6 +50,7 @@ exportRecords(
   events = NULL,
   labels = TRUE,
   dates = TRUE,
+  drop = NULL,
   survey = TRUE,
   dag = TRUE,
   checkboxLabels = FALSE,
@@ -66,6 +69,7 @@ exportRecords_offline(
   fields = NULL,
   forms = NULL,
   labels = TRUE,
+  drop = NULL,
   dates = TRUE,
   checkboxLabels = FALSE,
   colClasses = NA,
@@ -98,10 +102,14 @@ the data frame.}
 \item{dates}{Logical. Determines if date variables are converted to POSIXct 
 format during the download.}
 
+\item{drop}{An optional character vector of REDCap variable names to remove from the 
+dataset; defaults to NULL. E.g., \code{drop=c("date_dmy", "treatment")} 
+It is OK for drop to contain variables not present; these names are ignored.}
+
 \item{survey}{specifies whether or not to export the survey identifier field 
 (e.g., "redcap_survey_identifier") or survey timestamp fields 
 (e.g., form_name+"_timestamp") when surveys are utilized in the project. 
-If you do not pass in this flag, it will default to "false". If set to 
+If you do not pass in this flag, it will default to "true". If set to 
 "true", it will return the redcap_survey_identifier field and also the 
 survey timestamp field for a particular survey when at least 
 one field from that survey is being exported. NOTE: If the survey 

--- a/man/exportReports.Rd
+++ b/man/exportReports.Rd
@@ -12,6 +12,7 @@ exportReports(
   factors = TRUE,
   labels = TRUE,
   dates = TRUE,
+  drop = NULL,
   checkboxLabels = FALSE,
   ...
 )
@@ -22,6 +23,7 @@ exportReports(
   factors = TRUE,
   labels = TRUE,
   dates = TRUE,
+  drop = NULL,
   checkboxLabels = FALSE,
   ...
 )
@@ -32,6 +34,7 @@ exportReports(
   factors = TRUE,
   labels = TRUE,
   dates = TRUE,
+  drop = NULL,
   checkboxLabels = FALSE,
   ...,
   bundle = getOption("redcap_bundle"),
@@ -50,6 +53,10 @@ is returned as numeric codes or labelled factors.}
 \item{labels}{Logical.  Determines if the variable labels are applied to the data frame.}
 
 \item{dates}{Logical. Determines if date variables are converted to POSIXlt format during the download.}
+
+\item{drop}{An optional character vector of REDCap variable names to remove from the 
+dataset; defaults to NULL. E.g., \code{drop=c("date_dmy", "treatment")} 
+It is OK for drop to contain variables not present; these names are ignored.}
 
 \item{checkboxLabels}{Logical. Determines the format of labels in checkbox 
 variables.  If \code{FALSE} labels are applies as "Unchecked"/"Checked".  

--- a/tests/testthat/test-exportRecords.R
+++ b/tests/testthat/test-exportRecords.R
@@ -36,6 +36,16 @@ test_that(
 )
 
 test_that(
+  "fields in the drop= arg are not returned", 
+  {
+    forms_to_drop <- c("treatment")
+    Records <- exportRecords(rcon, 
+                             drop = forms_to_drop)
+    expect_false("treatment" %in% names(Records))
+  }
+)
+
+test_that(
   "records returned only for designated records", 
   {
     records_to_get <- 1:3


### PR DESCRIPTION
- add drop= argument to exportRecords that takes a character vector E.g. `drop=c("field_name_one", "field_name_2") and does not return the fields listed
- add drop= to exportRecords_offline
- Create test case for drop argument