### PR TITLE
Updating importFiles, along with exportFiles and deleteFiles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: redcapAPI
 Type: Package
 Title: Interface to 'REDCap'
-Version: 2.6.1
+Version: 2.6.2
 Authors@R: c(
     person("Shawn", "Garbett", email = "shawn.garbett@vumc.org",
            comment = c(ORCID="0000-0003-4079-5621"),

--- a/R/reconstituteFileFromExport.R
+++ b/R/reconstituteFileFromExport.R
@@ -59,6 +59,7 @@ reconstituteFileFromExport <- function(response,
   filename <- gsub(pattern = "(^[[:print:]]+; name=|\")", 
                    replacement = "", 
                    x = response$headers$'content-type')
+  filename <- sub("[;]charset.+$", "", filename)
   
   # Add Prefix to the file name -------------------------------------
   

--- a/man/deleteFiles.Rd
+++ b/man/deleteFiles.Rd
@@ -12,9 +12,12 @@ deleteFiles(rcon, record, field, event, ...)
   record = NULL,
   field = NULL,
   event = NULL,
+  repeat_instance = NULL,
   ...,
   bundle = getOption("redcap_bundle"),
-  error_handling = getOption("redcap_error_handling")
+  error_handling = getOption("redcap_error_handling"),
+  config = list(),
+  api_param = list()
 )
 }
 \arguments{
@@ -30,10 +33,22 @@ supplied for a longitudinal project, the API will return an error message.}
 
 \item{...}{Arguments to be passed to other methods}
 
+\item{repeat_instance}{The repeat instance number of the repeating
+event or the repeating instrument. When available in your instance
+of REDCap, and passed as NULL, the API will assume a value of 1.}
+
 \item{bundle}{A \code{redcapBundle} object as created by \code{exportBundle}.}
 
 \item{error_handling}{An option for how to handle errors returned by the API.
 see \code{\link{redcap_error}}}
+
+\item{config}{\code{list} Additional configuration parameters to pass to 
+\code{\link[httr]{POST}}. These are appended to any parameters in 
+\code{rcon$config}.}
+
+\item{api_param}{\code{list} Additional API parameters to pass into the
+body of the API call. This provides users to execute calls with options
+that may not otherwise be supported by \code{redcapAPI}.}
 }
 \description{
 This function allows you to remove a document that has been 

--- a/man/exportFiles.Rd
+++ b/man/exportFiles.Rd
@@ -9,7 +9,7 @@ exportFiles(
   rcon,
   record,
   field,
-  event,
+  event = NULL,
   dir,
   filePrefix = TRUE,
   ...,
@@ -23,9 +23,12 @@ exportFiles(
   event = NULL,
   dir,
   filePrefix = TRUE,
+  repeat_instance = NULL,
   ...,
   bundle = getOption("redcap_bundle"),
-  error_handling = getOption("redcap_error_handling")
+  error_handling = getOption("redcap_error_handling"),
+  config = list(),
+  api_param = list()
 )
 }
 \arguments{
@@ -50,8 +53,20 @@ The file name is always the same name of the file as it exists in REDCap}
 
 \item{bundle}{A \code{redcapBundle} object as created by \code{exportBundle}.}
 
+\item{repeat_instance}{The repeat instance number of the repeating
+event or the repeating instrument. When available in your instance
+of REDCap, and passed as NULL, the API will assume a value of 1.}
+
 \item{error_handling}{An option for how to handle errors returned by the API.
 see \code{\link{redcap_error}}}
+
+\item{config}{\code{list} Additional configuration parameters to pass to 
+\code{\link[httr]{POST}}. These are appended to any parameters in 
+\code{rcon$config}.}
+
+\item{api_param}{\code{list} Additional API parameters to pass into the
+body of the API call. This provides users to execute calls with options
+that may not otherwise be supported by \code{redcapAPI}.}
 }
 \description{
 A single file from a single record is retrieved.  The behavior 

--- a/man/importFiles.Rd
+++ b/man/importFiles.Rd
@@ -27,7 +27,9 @@ importFiles(
   repeat_instance = NULL,
   ...,
   bundle = NULL,
-  error_handling = getOption("redcap_error_handling")
+  error_handling = getOption("redcap_error_handling"),
+  config = list(),
+  api_param = list()
 )
 }
 \arguments{
@@ -58,6 +60,14 @@ of REDCap, and passed as NULL, the API will assume a value of 1.}
 
 \item{error_handling}{An option for how to handle errors returned by the API.
 see \code{\link{redcap_error}}}
+
+\item{config}{\code{list} Additional configuration parameters to pass to 
+\code{\link[httr]{POST}}. These are appended to any parameters in 
+\code{rcon$config}.}
+
+\item{api_param}{\code{list} Additional API parameters to pass into the
+body of the API call. This provides users to execute calls with options
+that may not otherwise be supported by \code{redcapAPI}.}
 }
 \description{
 A single file may be attached to a single record.  The 

--- a/tests/testthat/test-exportDeleteImportFiles.R
+++ b/tests/testthat/test-exportDeleteImportFiles.R
@@ -1,0 +1,319 @@
+context("exportFiles, deleteFiles, importFiles")
+
+rcon <- redcapConnection(url, API_KEY)
+
+test_that(
+  "export, delete, and import a file in a longitudinal project", 
+  {
+    temp_dir <- tempdir()
+    target_file <- "30-event_1_arm_1-FileForImportExportTesting.txt"
+  
+    # Export the file
+    expect_message(
+      exportFiles(rcon, 
+                  record = "30", 
+                  field = "file_import_field", 
+                  event = "event_1_arm_1", 
+                  dir = temp_dir, 
+                  filePrefix = TRUE),
+      "The file was saved to '.+30-event_1_arm_1-FileForImportExportTesting.txt"
+    )
+    
+    # Delete the file
+    expect_message(
+      deleteFiles(rcon, 
+                  record = "30", 
+                  field = "file_import_field", 
+                  event = "event_1_arm_1"), 
+      "The file was successfully deleted"
+    )
+    
+    # Reimport the file
+    file_no_prefix <- sub("(^.+)(FileFor.+$)", "\\2", target_file)
+    file.rename(file.path(temp_dir, target_file), 
+                file.path(temp_dir, file_no_prefix))
+    expect_message(
+      importFiles(rcon,
+                  file = file.path(temp_dir, file_no_prefix), 
+                  record = "30", 
+                  field = "file_import_field", 
+                  event = "event_1_arm_1", 
+                  overwrite = FALSE, 
+                  repeat_instance = NULL), 
+      "The file was successfully uploaded"
+    )
+    
+    # And now import it again with an overwrite
+    expect_message(
+      importFiles(rcon,
+                  file = file.path(temp_dir, file_no_prefix), 
+                  record = "30", 
+                  field = "file_import_field", 
+                  event = "event_1_arm_1", 
+                  overwrite = TRUE, 
+                  repeat_instance = NULL), 
+      "The file was successfully uploaded"
+    )
+    
+    # Attempt an import without overwrite = TRUE. Results in error
+    expect_error(
+      importFiles(rcon,
+                  file = file.path(temp_dir, file_no_prefix), 
+                  record = "30", 
+                  field = "file_import_field", 
+                  event = "event_1_arm_1", 
+                  overwrite = FALSE, 
+                  repeat_instance = NULL), 
+      "A file exists and overwrite=FALSE"
+    )
+  }
+)
+
+
+test_that(
+  "deleteFiles Argument Checking", 
+  {
+    # rcon is redcapApiConnection
+    expect_error(deleteFiles(rcon = mtcars), 
+                 "no applicable method for 'deleteFiles'")
+    
+    # record is not character (may also be numeric)
+    expect_error(deleteFiles(rcon, 
+                             record = TRUE), 
+                 "'record': Must be of type 'character'")
+    
+    # record is a character(1)
+    expect_error(deleteFiles(rcon, 
+                             record = c("30", "31")), 
+                 "'record': Must have length 1")
+    
+    # field is character(1)
+    expect_error(deleteFiles(rcon, 
+                             field = 1), 
+                 "'field': Must be of type 'character'")
+
+    expect_error(deleteFiles(rcon, 
+                             field = c("field1", "field2")), 
+                 "'field': Must have length 1")    
+    
+    # event is character(1)
+    expect_error(deleteFiles(rcon, 
+                             event = 1), 
+                 "'event': Must be of type 'character'")
+    
+    expect_error(deleteFiles(rcon, 
+                             event = c("event1", "event2")), 
+                 "'event': Must have length 1") 
+    
+    # repeat_instance is integerish(1)
+    expect_error(deleteFiles(rcon, 
+                             repeat_instance = pi), 
+                 "'repeat_instance': Must be of type 'integerish'")
+    
+    expect_error(deleteFiles(rcon, 
+                             repeat_instance = c(1, 2)), 
+                 "'repeat_instance': Must have length 1") 
+  }
+)
+
+
+test_that(
+  "exportFiles Argument Checking", 
+  {
+    # rcon is redcapApiConnection
+    expect_error(exportFiles(rcon = mtcars), 
+                 "no applicable method for 'exportFiles'")
+    
+    # record is not character (may also be numeric)
+    expect_error(exportFiles(rcon,
+                             record = TRUE, 
+                             field = "field_name", 
+                             dir = "dir"), 
+                 "'record': Must be of type 'character'")
+    
+    # record is a character(1)
+    expect_error(exportFiles(rcon, 
+                             record = c("30", "31"), 
+                             field = "field_name", 
+                             dir = "dir"), 
+                 "'record': Must have length 1")
+    
+    # field is character(1)
+    expect_error(exportFiles(rcon, 
+                             record = 1,
+                             field = 1, 
+                             dir = "dir"), 
+                 "'field': Must be of type 'character'")
+    
+    expect_error(exportFiles(rcon,
+                             record = 1, 
+                             field = c("field1", "field2"), 
+                             dir = "dir"), 
+                 "'field': Must have length 1")    
+    
+    # event is character(1)
+    expect_error(exportFiles(rcon, 
+                             record = 1, 
+                             field = "field", 
+                             dir = "dir",
+                             event = 1), 
+                 "'event': Must be of type 'character'")
+    
+    expect_error(exportFiles(rcon, 
+                             record = 1, 
+                             field = "field", 
+                             dir = "dir",
+                             event = c("event1", "event2")), 
+                 "'event': Must have length 1") 
+    
+    # dir is character(1)
+    expect_error(exportFiles(rcon, 
+                             record = 1, 
+                             field = "field", 
+                             dir = 123,
+                             event = NULL), 
+                 "'dir': Must be of type 'character'")
+    
+    expect_error(exportFiles(rcon, 
+                             record = 1, 
+                             field = "field", 
+                             dir = c("dir1", "dir2"),
+                             event = NULL), 
+                 "'dir': Must have length 1") 
+    
+    # filePrefix is logical(1)
+    expect_error(exportFiles(rcon, 
+                             record = 1, 
+                             field = "field", 
+                             dir = "dir", 
+                             event = NULL, 
+                             filePrefix = c(TRUE, FALSE)), 
+                 "'filePrefix': Must have length 1")
+    
+    expect_error(exportFiles(rcon, 
+                             record = 1, 
+                             field = "field", 
+                             dir = "dir", 
+                             event = NULL, 
+                             filePrefix = "TRUE"), 
+                 "'filePrefix': Must be of type 'logical'")
+    
+    # repeat_instance is integerish(1)
+    expect_error(exportFiles(rcon, 
+                             record = 1, 
+                             field = "file_import_field", 
+                             dir = "dir", 
+                             event = NULL,
+                             repeat_instance = pi), 
+                 "'repeat_instance': Must be of type 'integerish'")
+    
+    expect_error(exportFiles(rcon, 
+                             record = 1, 
+                             field = "file_import_field", 
+                             dir = "dir", 
+                             event = NULL,
+                             repeat_instance = c(1, 2)), 
+                 "'repeat_instance': Must have length 1") 
+  }
+)
+
+
+test_that(
+  "importFiles Argument Checking", 
+  {
+    # rcon is redcapApiConnection
+    expect_error(importFiles(rcon = mtcars), 
+                 "no applicable method for 'importFiles'")
+    
+    # file is a character(1)
+    expect_error(importFiles(rcon, 
+                             file = 123, 
+                             record = "30", 
+                             field = "field_name"), 
+                 "'file': Must be of type 'character'")
+    
+    expect_error(importFiles(rcon, 
+                             file = c("file1", "file2"), 
+                             record = "30", 
+                             field = "field_name"), 
+                 "'file': Must have length 1")
+    
+    # record is not character (may also be numeric)
+    expect_error(importFiles(rcon,
+                             record = TRUE,
+                             field = "fieldname",
+                             file = "filename"), 
+                 "'record': Must be of type 'character'")
+    
+    # record is a character(1)
+    expect_error(importFiles(rcon, 
+                             record = c("30", "31"), 
+                             field = "field_name", 
+                             file = "filename"), 
+                 "'record': Must have length 1")
+    
+    # field is character(1)
+    expect_error(importFiles(rcon, 
+                             record = 1,
+                             field = 1, 
+                             file = "filename"), 
+                 "'field': Must be of type 'character'")
+    
+    expect_error(importFiles(rcon,
+                             record = 1, 
+                             field = c("field1", "field2"), 
+                             file = "filename"), 
+                 "'field': Must have length 1")    
+    
+    # event is character(1)
+    expect_error(importFiles(rcon, 
+                             record = 1, 
+                             field = "field", 
+                             file = "filename",
+                             event = 1), 
+                 "'event': Must be of type 'character'")
+    
+    expect_error(importFiles(rcon, 
+                             record = 1, 
+                             field = "field", 
+                             file = "filename",
+                             event = c("event1", "event2")), 
+                 "'event': Must have length 1") 
+    
+    
+    # overwrite is logical(1)
+    expect_error(importFiles(rcon, 
+                             record = 1, 
+                             field = "field", 
+                             event = NULL,
+                             file = "filename",
+                             overwrite = c(TRUE, FALSE)), 
+                 "'overwrite': Must have length 1")
+    
+    expect_error(importFiles(rcon, 
+                             record = 1, 
+                             field = "field", 
+                             dir = "dir", 
+                             event = NULL,
+                             file = "filename",
+                             overwrite = "TRUE"), 
+                 "'overwrite': Must be of type 'logical'")
+    
+    # repeat_instance is integerish(1)
+    expect_error(importFiles(rcon, 
+                             record = 1, 
+                             field = "file_import_field", 
+                             file = "filename",
+                             event = NULL,
+                             repeat_instance = pi), 
+                 "'repeat_instance': Must be of type 'integerish'")
+    
+    expect_error(importFiles(rcon, 
+                             record = 1, 
+                             field = "file_import_field", 
+                             file = "filename",
+                             event = NULL,
+                             repeat_instance = c(1, 2)), 
+                 "'repeat_instance': Must have length 1") 
+  }
+)


### PR DESCRIPTION
Addresses #62  - event argument is set to NULL for non-longitudinal projects
In order to provide accurate testing, testing is provided for deleteFiles, exportFiles, and importFiles.
All three of these are brought up to new style guidelines.

I have all tests passing, check passes with no warnings, errors, or notes.

Set version to 2.6.2