### PR TITLE
Add timeout strategy

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: redcapAPI
 Type: Package
 Title: Interface to 'REDCap'
-Version: 2.6.1
+Version: 2.6.2
 Authors@R: c(
     person("Shawn", "Garbett", email = "shawn.garbett@vumc.org",
            comment = c(ORCID="0000-0003-4079-5621"),

--- a/R/makeApiCall.R
+++ b/R/makeApiCall.R
@@ -29,6 +29,15 @@
 #'   The config list is a list of parameters to pass to \code{\link[httr]{POST}}. 
 #'   Refer to documentation there for details.
 #'   
+#'   Using the settings stored in the \code{redcapConnection} object, a response
+#'   code of 408 (Request Timeout), 500 (Internal Server Error), 
+#'   502 (Bad Gateway), 503 (Service Unavailable), or 504 (Gateway Timeout)
+#'   will prompt reattempts at calling the API. See \code{\link{redcapConnection}}
+#'   for details. If the API reaches its attempt limit without resolving to 
+#'   any other code, the last response is returned. If any other response
+#'   code is returned at any point in the retry loop, the loop breaks and 
+#'   returns that response.
+#'   
 #' @author Benjamin Nutter
 #' 
 #' @references
@@ -143,25 +152,81 @@ makeApiCall <- function(rcon,
                           add = coll)
   
   checkmate::assert_list(x = body, 
+                         names = "named",
                          add = coll)
   
   checkmate::assert_list(x = config, 
+                         names = "named",
                          add = coll)
   
   checkmate::reportAssertions(coll)
   
   # Functional Code -------------------------------------------------
   
-  httr::POST(
-    url = rcon$url, 
-    body = c(list(token = rcon$token), 
-             body),
-    config = c(rcon$config, 
-               config) 
-  )
+  for (i in seq_len(rcon$retries())){
+    response <-   
+      httr::POST(url = rcon$url, 
+                 body = c(list(token = rcon$token), 
+                          body),
+                 config = c(rcon$config, 
+                            config))
+    
+    is_retry_eligible <- .makeApiCall_isRetryEligible(response = response)
+    
+    if (!is_retry_eligible) 
+      break
+    
+    # The attempt failed. Produce a message detailing the failure (when not quiet)
+    if (!rcon$retry_quietly()){
+      .makeApiCall_retryMessage(rcon = rcon, 
+                                response = response, 
+                                iteration = i)
+    }
+    
+    # Wait the designated time until trying again.
+    # when i = rcon$retries(), we've made all our attempts, we don't need to wait to exit the loop 
+    if (i < rcon$retries()) { 
+      Sys.sleep(rcon$retry_interval()[i])
+    }
+  }
+  
+  response
 }
 
-# Tests to perform --------------------------------------------------
-# *  Throw an error if \code{rcon} is not a \code{redcapApiConnection}
-# * Throw an error if \code{body} is not a list.
-# *  Throw an error if \code{config} is not a list.
+####################################################################
+# Unexported
+
+.makeApiCall_isRetryEligible <- function(response){
+  # the return from this is a logical indicating if we are ready to break the loop.
+  # we want to break the loop in cases where the response is anything that does
+  # not justify a retry. 
+  # It's somewhat silly to have this as a separate method, but it allows us
+  # to test that we can hit the retry conditions based on the status code
+  # without having to force one of these conditions onto the server. 
+  # See tests for .makeApiCall_isRetryEligible in test/testthat/test-makeApiCall.R
+  
+  retry_eligible <- response$status_code %in% c(408, 500, 502, 503, 504)
+  
+  return(retry_eligible)
+}
+
+
+
+.makeApiCall_retryMessage <- function(rcon, 
+                                      response, 
+                                      iteration){
+  msg_part1 <- sprintf("API attempt %s of %s failed. ", 
+                       iteration, 
+                       rcon$retries())
+  msg_part2 <- 
+    if (iteration < rcon$retries()){
+      sprintf("Trying again in %s seconds. ", 
+              rcon$retry_interval()[iteration])
+    } else { # when i = retries, we aren't actually going to try again. 
+      ""
+    }
+  
+  msg_part3 <- as.character(response)
+  
+  message(msg_part1, msg_part2, msg_part3)
+}

--- a/man/fieldChoiceMapping.Rd
+++ b/man/fieldChoiceMapping.Rd
@@ -9,9 +9,9 @@
 https://stackoverflow.com/questions/23961022/split-strings-on-first-and-last-commas
 }
 \usage{
-fieldChoiceMapping(object, ...)
+fieldChoiceMapping(object, field_name, ...)
 
-\method{fieldChoiceMapping}{character}(object, ...)
+\method{fieldChoiceMapping}{character}(object, field_name, ...)
 
 \method{fieldChoiceMapping}{redcapApiConnection}(object, field_name, ...)
 }
@@ -20,10 +20,10 @@ fieldChoiceMapping(object, ...)
 field choices (i.e. \code{meta_data$select_choices_or_calculations}), 
 or a \code{redcapConnection} object.}
 
-\item{...}{arguments to pass to other methods.}
-
 \item{field_name}{\code{character(1)} gives the field name for which to 
 make the choice mapping.}
+
+\item{...}{arguments to pass to other methods.}
 }
 \value{
 Returns a matrix with two columns, \code{choice_value} and \code{choice_label}

--- a/man/makeApiCall.Rd
+++ b/man/makeApiCall.Rd
@@ -38,6 +38,15 @@ The intent of this function is to provide an approach to execute
   
   The config list is a list of parameters to pass to \code{\link[httr]{POST}}. 
   Refer to documentation there for details.
+  
+  Using the settings stored in the \code{redcapConnection} object, a response
+  code of 408 (Request Timeout), 500 (Internal Server Error), 
+  502 (Bad Gateway), 503 (Service Unavailable), or 504 (Gateway Timeout)
+  will prompt reattempts at calling the API. See \code{\link{redcapConnection}}
+  for details. If the API reaches its attempt limit without resolving to 
+  any other code, the last response is returned. If any other response
+  code is returned at any point in the retry loop, the loop breaks and 
+  returns that response.
 }
 \examples{
 \dontrun{

--- a/man/redcapConnection.Rd
+++ b/man/redcapConnection.Rd
@@ -8,7 +8,10 @@
 redcapConnection(
   url = getOption("redcap_api_url"),
   token,
-  config = httr::config()
+  config = httr::config(),
+  retries = 5,
+  retry_interval = 2^(seq_len(retries)),
+  retry_quietly = TRUE
 )
 
 \method{print}{redcapApiConnection}(x, ...)
@@ -26,6 +29,18 @@ certificates, ssl version, etc. For the majority of users, this does
 not need to be altered.  See Details for more about this argument's 
 purpose and the \code{redcapAPI} wiki for specifics on its use.}
 
+\item{retries}{\code{integerish(1)}. Sets the number of attempts to make to the
+API if a timeout error is encountered. Must be a positive value.}
+
+\item{retry_interval}{\code{numeric}. Sets the intervals (in seconds) at 
+which retries are attempted. By default, set at a \code{2^r} where 
+\code{r} is the \code{r}th retry (ie, 2, 4, 8, 16, ...). For fixed 
+intervals, provide a single value. Values will be recycled to match
+the number of retries.}
+
+\item{retry_quietly}{\code{logical(1)}. When \code{FALSE}, messages will 
+be shown giving the status of the API calls. Defaults to \code{TRUE}.}
+
 \item{x}{\code{redcapConnection} object to be printed}
 
 \item{...}{arguments to pass to other methods}
@@ -36,11 +51,12 @@ using the REDCap API
 }
 \details{
 \code{redcapConnection} objects will retrieve and cache various forms of 
-project information. This can make metadata, arms, events, fieldnames, 
-arm-event mappings, users, version, and project information available
+project information. This can make metadata, arms, events, instruments, fieldnames, 
+arm-event mappings, users, version, project information, and fileRepository available
 directly from the \code{redcapConnection} object. Take note that 
 the retrieval of these objects uses the default values of the respective
-export functions. 
+export functions (excepting the file repository, 
+which uses \code{recursive = TRUE}). 
 
 For each of these objects, there are four methods that can be called from 
 the \code{redcapConnection} object: the get method (called via
@@ -50,6 +66,16 @@ the flush method (\code{rcon$flush_metadata}), which removes the cached value;
 and the refresh method (\code{rcon$refresh_metadata}), which replaces the 
 current value with a new call to the API. There is also a \code{flush_all}
 and \code{refresh_all} method.
+
+The \code{redcapConnection} object also stores the user preferences for 
+handling repeated attempts to call the API. In the event of a timeout 
+error or server unavailability, these settings allow a system pause before
+attempting another API call. In the event all of the retries fail, the 
+error message of the last attempt will be returned. These settings may 
+be altered at any time using the methods \code{rcon$set_retries(r)}, 
+\code{rcon$set_retry_interval(ri)}, and \code{rcon$set_retry_quietly(rq)}. 
+The argument to these functions have the same requirements as the 
+corresponding arguments to \code{redcapConnection}.
 
 For convenience, you may consider using 
 \code{options(redcap_api_url=[your URL here])} in your RProfile.

--- a/tests/testthat/test-makeApiCall.R
+++ b/tests/testthat/test-makeApiCall.R
@@ -1,0 +1,90 @@
+context("makeApiCall.R")
+
+# Note: This file will only test that arguments fail appropriately, or
+# that submethods perform as expected. the makeApiCall function 
+# is ubiquitous throughout the package. If we break it, it's bound
+# to pop up in other tests.
+
+rcon <- redcapConnection(url = url, token = API_KEY)
+
+test_that(
+  "Return an error if rcon is not of class redcapApiConnection", 
+  {
+    expect_error(makeApiCall(mtcars), 
+                 "'rcon': Must inherit from class 'redcapApiConnection'")
+  }
+)
+
+test_that(
+  "Return an error if body is not a named list", 
+  {
+    expect_error(makeApiCall(rcon, 
+                             letters), 
+                 "'body': Must be of type 'list'")
+    
+    expect_error(makeApiCall(rcon, 
+                             list(1, 2, 3)), 
+                 "'body': Must have names")
+  }
+)
+
+test_that(
+  "Return an error if config is not a named list", 
+  {
+    expect_error(makeApiCall(rcon, 
+                             config = letters), 
+                 "'config': Must be of type 'list'")
+    
+    expect_error(makeApiCall(rcon, 
+                             config = list(1, 2, 3)), 
+                 "'config': Must have names")
+  }
+)
+
+# Test .makeApiCall_validateResponse
+
+test_that(
+  ".makeApiCall_isRetryEligible returns appropriate logical values", 
+  {
+    response <- makeApiCall(rcon, 
+                            body = list(content = "metadata", 
+                                        format = "csv"))
+    
+    # list of codes from   https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
+    all_codes <- c(100, 101, 102, 103, 
+                   200, 201, 202, 203, 304, 205, 206, 207, 208, 226, 
+                   300, 301, 302, 303, 304, 305, 306, 307, 308, 
+                   400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 
+                   416, 417, 418, 421, 422, 423, 424, 425, 426, 428, 429, 431, 451, 
+                   500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511)
+    
+    eligible_codes <- c(408, 500, 502, 503, 504)
+    
+    ideal <- all_codes %in% eligible_codes
+    
+    actual <- rep(FALSE, length(all_codes))
+    
+    for (i in seq_along(all_codes)){
+      response$status_code <- all_codes[i]
+      actual[i] <- .makeApiCall_isRetryEligible(response)
+    }
+    
+    expect_equal(ideal, actual)
+  }
+)
+
+test_that(
+  ".makeApiCall_retryMessage gives appropriate messages", 
+  {
+    response <- makeApiCall(rcon, 
+                            body = list(content = "invalid-content", 
+                                        format = "csv"))
+    
+    expect_message(.makeApiCall_retryMessage(rcon, response, 1), 
+                   "API attempt 1 of 5 failed. Trying again in 2 seconds. ERROR: The value of the parameter \"content\" is not valid")
+    
+    expect_message(.makeApiCall_retryMessage(rcon, response, rcon$retries()), 
+                   sprintf("API attempt %s of %s failed. ERROR: The value of the parameter \"content\" is not valid", 
+                           rcon$retries(), rcon$retries()))
+  }
+)

--- a/tests/testthat/test-redcapConnection.R
+++ b/tests/testthat/test-redcapConnection.R
@@ -1,18 +1,68 @@
 context("redcapConnection")
 
 test_that("redcapApiConnection can be created",
-  expect_equal(
-    class(redcapConnection(url = url, token = API_KEY)),
-    "redcapApiConnection"
-  )
+          expect_equal(
+            class(redcapConnection(url = url, token = API_KEY)),
+            "redcapApiConnection"
+          )
 )
 
 test_that("redcapConnection throws an error if url is missing",
-  expect_error(redcapConnection(token = API_KEY))
+          expect_error(redcapConnection(token = API_KEY))
 )
 
 test_that("redcapConnection throws an  error if token is missing",
-  expect_error(redcapConnection(url = url))
+          expect_error(redcapConnection(url = url))
+)
+
+test_that(
+  "return an error if retries is not integerish(1) > 0", 
+  {
+    expect_error(redcapConnection(url = url, 
+                                  token = API_KEY, 
+                                  retries = "5"), 
+                 "Variable 'retries': Must be of type 'integerish'")
+    
+    expect_error(suppressWarnings(redcapConnection(url = url, 
+                                                   token = API_KEY, 
+                                                   retries = 1:5)), 
+                 "'retries': Must have length 1")
+    
+    expect_error(redcapConnection(url = url, 
+                                  token = API_KEY, 
+                                  retries = 0), 
+                 "Variable 'retries': Element 1 is not [>][=] 1")
+  }
+)
+
+test_that(
+  "return an error if retry_interval is not numeric >= 0", 
+  {
+    expect_error(redcapConnection(url = url, 
+                                  token = API_KEY, 
+                                  retry_interval = "0"), 
+                 "'retry_interval': Must be of type 'numeric'")
+    
+    expect_error(redcapConnection(url = url, 
+                                  token = API_KEY, 
+                                  retry_interval = -1), 
+                 "'retry_interval': Element 1 is not [>][=] 0")
+  }
+)
+
+test_that(
+  "return an error if retry_quietly is not logical(1)", 
+  {
+    expect_error(redcapConnection(url = url, 
+                                  token = API_KEY, 
+                                  retry_quietly = c(TRUE, FALSE)), 
+                 "'retry_quietly': Must have length 1")
+    
+    expect_error(redcapConnection(url = url, 
+                                  token = API_KEY, 
+                                  retry_quietly = "TRUE"), 
+                 "'retry_quietly': Must be of type 'logical'")
+  }
 )
 
 # Caching tests -----------------------------------------------------
@@ -189,3 +239,44 @@ test_that(
   }
 )
 
+test_that(
+  "retrieve and set retries", 
+  {
+    expect_equal(rcon$retries(), 5)
+    expect_error(rcon$set_retries("3"))
+    
+    rcon$set_retries(4)
+    expect_equal(rcon$retries(), 4)
+    rcon$set_retries(5)
+  }
+)
+
+test_that(
+  "retrieve and set retry_interval", 
+  {
+    expect_equal(rcon$retry_interval(), 
+                 c(2^(1:5)))
+    
+    expect_error(rcon$set_retry_interval(-3))
+    
+    rcon$set_retry_interval(3)
+    expect_equal(rcon$retry_interval(), 
+                 rep(3, 5))
+    
+    rcon$set_retry_interval(2^(1:5))
+  }
+)
+
+test_that(
+  "retrieve and set retry_quietly", 
+  {
+    expect_true(rcon$retry_quietly())
+    
+    expect_error(rcon$set_retry_quietly("FALSE"))
+    
+    rcon$set_retry_quietly(FALSE)
+    expect_false(rcon$retry_quietly())
+    
+    rcon$set_retry_quietly(TRUE)
+  }
+)


### PR DESCRIPTION
`redcapConnection` gains the following arguments

* retries - determines how many attempts to make at the API call if there is a time out error.
* retry_interval - how long to wait before attempts. Defaults to 2^(1:5), (2, 4, 8, 16, 32). It isn't quite what you described in the issue description, but it was similar, easy to implement, and easy to modify by the user.
* retry_quietly - if FALSE, messages about the retry attempts will be displayed. I suspect these may be useful in future debugging efforts. Defaults to TRUE.

`redcapConnection` also gains methods to extract and set those values (ie `rcon$retries()` and `rcon$set_retries(4)`. 

`makeApiCall` utilizes the values from the redcapConnection in a loop with `retries` iterations and the following behaviors

1. If the returns a code of 408, 500, 502, 503, 504, it is eligible for a retry
2. If the attempt has another code break and return the result with its error
3. Otherwise, wait the designated time and try again

All tests pass. Check has no errors, warnings, or notes.

Note: there are fewer commits than what you may have noticed from earlier discussion. My earlier work was branched off of a source that had all the import/export/delete file work that hasn't been implemented yet. This is a clean request with just the retry strategy.