### PR TITLE
Issue 72 import records

### DIFF
--- a/R/importRecords.R
+++ b/R/importRecords.R
@@ -229,16 +229,18 @@ importRecords.redcapApiConnection <- function(rcon,
   # Confirm that date fields are either character, Date class, or POSIXct
   date_vars <- MetaData$field_name[grepl("date_", MetaData$text_validation_type_or_show_slider_number)]
   
-  bad_date_fmt <- 
-    !vapply(X = data[date_vars], 
-            FUN = function(x) is.character(x) | "Date" %in% class(x) | "POSIXct" %in% class(x),
-            FUN.VALUE = logical(1))
-  
-  if (any(bad_date_fmt))
-  {
-    coll$push(paste0("The variables '", 
-                     paste(date_vars[bad_date_fmt], collapse="', '"),
-                     "' must have class Date, POSIXct, or character."))
+  if (any(date_vars %in% names(data))){
+    bad_date_fmt <- 
+      !vapply(X = data[date_vars], 
+              FUN = function(x) is.character(x) | "Date" %in% class(x) | "POSIXct" %in% class(x),
+              FUN.VALUE = logical(1))
+    
+    if (any(bad_date_fmt))
+    {
+      coll$push(paste0("The variables '", 
+                       paste(date_vars[bad_date_fmt], collapse="', '"),
+                       "' must have class Date, POSIXct, or character."))
+    }
   }
   
   # Remove calculated fields

--- a/man/importRecords.Rd
+++ b/man/importRecords.Rd
@@ -9,7 +9,7 @@ importRecords(
   rcon,
   data,
   overwriteBehavior = c("normal", "overwrite"),
-  returnContent = c("count", "ids", "nothing"),
+  returnContent = c("count", "ids", "nothing", "auto_ids"),
   returnData = FALSE,
   logfile = "",
   ...
@@ -19,9 +19,10 @@ importRecords(
   rcon,
   data,
   overwriteBehavior = c("normal", "overwrite"),
-  returnContent = c("count", "ids", "nothing"),
+  returnContent = c("count", "ids", "nothing", "auto_ids"),
   returnData = FALSE,
   logfile = "",
+  force_auto_number = FALSE,
   ...,
   batch.size = -1,
   error_handling = getOption("redcap_error_handling"),
@@ -40,7 +41,9 @@ overwrite data in the REDCap database.}
 
 \item{returnContent}{Character string.  'count' returns the number of
 records imported; 'ids' returns the record ids that are imported;
-'nothing' returns no message.}
+'nothing' returns no message; 'auto_ids' returns a list of pairs of all 
+record IDs that were imported. If used when \code{force_auto_number = FALSE}, 
+the value will be changed to \code{'ids'}.}
 
 \item{returnData}{Logical.  Prevents the REDCap import and instead
 returns the data frame that would have been given
@@ -55,6 +58,20 @@ log of errors and warnings about the data.
 If \code{""}, the log is printed to the console.}
 
 \item{...}{Arguments to be passed to other methods.}
+
+\item{force_auto_number}{\code{logical(1)} If record auto-numbering has been
+enabled in the project, it may be desirable to import records where each 
+record's record name is automatically determined by REDCap (just as it 
+does in the user interface). If this parameter is set to 'true', the 
+record names provided in the request will not be used (although they 
+are still required in order to associate multiple rows of data to an 
+individual record in the request), but instead those records in the 
+request will receive new record names during the import process. 
+NOTE: To see how the provided record names get translated into new auto
+ record names, the returnContent parameter should be set to 'auto_ids', 
+ which will return a record list similar to 'ids' value, but it will have
+ the new record name followed by the provided record name in the request, 
+ in which the two are comma-delimited.}
 
 \item{batch.size}{Specifies size of batches.  A negative value
 indicates no batching.}

--- a/tests/testthat/test-11-records-argValidation.R
+++ b/tests/testthat/test-11-records-argValidation.R
@@ -252,7 +252,7 @@ test_that(
     expect_error(importRecords(rcon, 
                                data = NewRecord, 
                                returnContent = "not an option"), 
-                 "'returnContent': Must be element of set [{]'count','ids','nothing', 'auto_ids'[}]")
+                 "'returnContent': Must be element of set [{]'count','ids','nothing','auto_ids'[}]")
   }
 )
 

--- a/tests/testthat/test-11-records-argValidation.R
+++ b/tests/testthat/test-11-records-argValidation.R
@@ -246,13 +246,13 @@ test_that(
 )
 
 test_that(
-  "Return an error if returnContent is not one of 'count', 'ids', 'nothing'", 
+  "Return an error if returnContent is not one of 'count', 'ids', 'nothing', 'auto_ids'", 
   {
     local_reproducible_output(width = 200)
     expect_error(importRecords(rcon, 
                                data = NewRecord, 
                                returnContent = "not an option"), 
-                 "'returnContent': Must be element of set [{]'count','ids','nothing'[}]")
+                 "'returnContent': Must be element of set [{]'count','ids','nothing', 'auto_ids'[}]")
   }
 )
 
@@ -285,6 +285,22 @@ test_that(
                                data = NewRecord, 
                                logfile = TRUE), 
                  "'logfile': Must be of type 'character'")
+  }
+)
+
+test_that(
+  "Return an error if force_auto_number is not logical(1)", 
+  {
+    local_reproducible_output(width = 200)
+    expect_error(importRecords(rcon, 
+                               data = NewRecord, 
+                               force_auto_number = c(TRUE, FALSE)), 
+                 "'force_auto_number': Must have length 1")
+    
+    expect_error(importRecords(rcon, 
+                               data = NewRecord, 
+                               force_auto_number = "TRUE"), 
+                 "'force_auto_number': Must be of type 'logical'")
   }
 )
 

--- a/tests/testthat/test-11-records-importRecords.R
+++ b/tests/testthat/test-11-records-importRecords.R
@@ -132,19 +132,22 @@ test_that(
   "import with Auto Numbering", 
   {
     Records <- exportRecordsTyped(rcon, mChoice = FALSE)
-    OneRecord <- exportRecordsTyped(rcon, mChoice = FALSE)[1,]
+    nrow(Records)
+    OneRecord <- Records[1,]
     
     next_record_id <- exportNextRecordName(rcon)
     
-    OneRecord$record_id <- 100
+    NewId <- importRecords(rcon, 
+                           data = OneRecord, 
+                           returnContent = 'auto_ids',
+                           force_auto_number = TRUE)
     
-    importRecords(rcon, 
-                  data = OneRecord, 
-                  returnContent = 'auto_ids',
-                  force_auto_number = TRUE)
+    expect_equal(NewId$id, next_record_id)
     
     After <- exportRecordsTyped(rcon)
     
-    deleteRecords(rcon, records = "100")
+    expect_equal(nrow(Records) + 1, nrow(After))
+    
+    deleteRecords(rcon, records = next_record_id)
   }
 )

--- a/tests/testthat/test-11-records-importRecords.R
+++ b/tests/testthat/test-11-records-importRecords.R
@@ -120,11 +120,13 @@ test_that(
   "mChoice fields are dropped", 
   {
     local_reproducible_output(width = 200)
+    require(Hmisc)
     TheData <- exportRecordsTyped(rcon)
     expect_message(importRecords(rcon, TheData), 
                    "The variable[(]s[)] file_import_field, prereq_checkbox, no_prereq_checkbox are not found in the project and/or cannot be imported.")
     TheDataAfter <- exportRecordsTyped(rcon)
     expect_true(identical(TheData, TheDataAfter))
+    detach("package:Hmisc", unload = TRUE)
   }
 )
 

--- a/tests/testthat/test-11-records-importRecords.R
+++ b/tests/testthat/test-11-records-importRecords.R
@@ -127,3 +127,24 @@ test_that(
     expect_true(identical(TheData, TheDataAfter))
   }
 )
+
+test_that(
+  "import with Auto Numbering", 
+  {
+    Records <- exportRecordsTyped(rcon, mChoice = FALSE)
+    OneRecord <- exportRecordsTyped(rcon, mChoice = FALSE)[1,]
+    
+    next_record_id <- exportNextRecordName(rcon)
+    
+    OneRecord$record_id <- 100
+    
+    importRecords(rcon, 
+                  data = OneRecord, 
+                  returnContent = 'auto_ids',
+                  force_auto_number = TRUE)
+    
+    After <- exportRecordsTyped(rcon)
+    
+    deleteRecords(rcon, records = "100")
+  }
+)

--- a/tests/testthat/test-11-records-importRecords.R
+++ b/tests/testthat/test-11-records-importRecords.R
@@ -115,3 +115,15 @@ test_that(
     file.remove(logfile_path)
   }
 )
+
+test_that(
+  "mChoice fields are dropped", 
+  {
+    local_reproducible_output(width = 200)
+    TheData <- exportRecordsTyped(rcon)
+    expect_message(importRecords(rcon, TheData), 
+                   "The variable[(]s[)] file_import_field, prereq_checkbox, no_prereq_checkbox are not found in the project and/or cannot be imported.")
+    TheDataAfter <- exportRecordsTyped(rcon)
+    expect_true(identical(TheData, TheDataAfter))
+  }
+)


### PR DESCRIPTION
Address #72 : any fields found in the data being imported that do not match an importable fields are removed with a message.

Also addresses https://github.com/nutterb/redcapAPI/issues/29 by providing arguments to access auto numbering. 

Tests are added for each of these changes.