### PR TITLE
test Logs allows NA in records logs

### DIFF
--- a/tests/testthat/test-08-logging.R
+++ b/tests/testthat/test-08-logging.R
@@ -155,7 +155,7 @@ test_that(
     
     Logs <- exportLogging(rcon, 
                           record = record_for_test)
-    all_record <- all(Logs$record %in% record_for_test)
+    all_record <- all(Logs$record %in% c(record_for_test, NA))
     expect_true(all_record)
   }
 )


### PR DESCRIPTION
Addresses #79 

I also ran the following to confirm it works with all records current in the logging. 

```
Records <- FullLog[!is.na(FullLog$record) & !grepl("user", FullLog$action), ]
records <- FullLog$record
records <- trimws(records)
records <- unique(records)

for (i in seq_along(records)){
  record_for_test <- records[i]
  Logs <- exportLogging(rcon, 
                        record = record_for_test)
  all_record <- all(Logs$record %in% c(record_for_test, NA))
  print(all_record)
}
```