### PR TITLE
102 fail on system field

### DIFF
--- a/R/exportRecordsTyped.R
+++ b/R/exportRecordsTyped.R
@@ -296,13 +296,28 @@ exportRecordsTyped.redcapApiConnection <-
 
   checkmate::reportAssertions(coll)
   
-  fields <- fields[!fields %in% REDCAP_SYSTEM_FIELDS] # redcapDataStructures.R
-  
   .exportRecordsTyped_validateFieldForm(rcon = rcon, 
                                         fields = fields, 
                                         drop_fields = drop_fields, 
                                         forms = forms, 
                                         coll = coll)
+  
+  ###################################################################
+  # Handle System Fields in the Request
+  
+  user_requested_system_fields <- length(fields) > 0 && any(fields %in% REDCAP_SYSTEM_FIELDS)
+  user_requested_only_system_fields <- length(fields) > 0 && all(fields %in% REDCAP_SYSTEM_FIELDS)
+  system_fields_user_requested <- REDCAP_SYSTEM_FIELDS[REDCAP_SYSTEM_FIELDS %in% fields]
+  
+  # The REDCap API won't accept system fields in the fields argument. 
+  # we have to remove them from the request.
+  fields <- fields[!fields %in% REDCAP_SYSTEM_FIELDS] # redcapDataStructures.R
+  
+  # But if the user only requested system fields, we need to provide 
+  # at least one actual field to get anything back from the API
+  if (user_requested_only_system_fields){
+    fields <- rcon$metadata()$field_name[1]
+  }
   
   # Check that the events exist in the project
   
@@ -358,6 +373,15 @@ exportRecordsTyped.redcapApiConnection <-
                                     csv_delimiter  = csv_delimiter, 
                                     batch_size     = batch_size)
     }
+  
+  if (user_requested_system_fields){
+    if (user_requested_only_system_fields){
+      Raw <- Raw[-1]
+    }
+    
+    unrequested_fields <- REDCAP_SYSTEM_FIELDS[!REDCAP_SYSTEM_FIELDS %in% system_fields_user_requested]
+    Raw <- Raw[!names(Raw) %in% unrequested_fields]
+  }
   
    ###################################################################
   # Process meta data for useful information
@@ -507,15 +531,29 @@ exportRecordsTyped.redcapOfflineConnection <- function(rcon,
   checkmate::reportAssertions(coll)
   
   ###################################################################
+  # Handle System Fields in the Request
+  
+  user_requested_system_fields <- length(fields) > 0 && any(fields %in% REDCAP_SYSTEM_FIELDS)
+  user_requested_only_system_fields <- length(fields) > 0 && all(fields %in% REDCAP_SYSTEM_FIELDS)
+  system_fields_user_requested <- REDCAP_SYSTEM_FIELDS[REDCAP_SYSTEM_FIELDS %in% fields]
+  
+  # The REDCap API won't accept system fields in the fields argument. 
+  # we have to remove them from the request.
+  fields <- fields[!fields %in% REDCAP_SYSTEM_FIELDS] # redcapDataStructures.R
+  
+  # But if the user only requested system fields, we need to provide 
+  # at least one actual field to get anything back from the API
+  if (user_requested_only_system_fields){
+    fields <- rcon$metadata()$field_name[1]
+  }
+  
+  ###################################################################
   # Combine fields, drop_fields, and forms into the fields that will 
   # be exported
   
   MetaData <- rcon$metadata()
   
   system_field <- REDCAP_SYSTEM_FIELDS[REDCAP_SYSTEM_FIELDS %in% names(rcon$records())]
-  if (length(fields) > 0){
-    system_field <- system_field[system_field %in% fields]
-  }
   
   fields <- .exportRecordsTyped_fieldsArray(rcon         = rcon, 
                                             fields       = fields, 
@@ -548,6 +586,16 @@ exportRecordsTyped.redcapOfflineConnection <- function(rcon,
   
   if (length(events) > 0)
     Raw <- Raw[Raw$redcap_event_name %in% events, ]
+  
+  
+  if (user_requested_system_fields){
+    if (user_requested_only_system_fields){
+      Raw <- Raw[-1]
+    }
+    
+    unrequested_fields <- REDCAP_SYSTEM_FIELDS[!REDCAP_SYSTEM_FIELDS %in% system_fields_user_requested]
+    Raw <- Raw[!names(Raw) %in% unrequested_fields]
+  }
   
   ###################################################################
   # Process meta data for useful information
@@ -712,7 +760,8 @@ exportRecordsTyped.redcapOfflineConnection <- function(rcon,
   ProjectFields <- rcon$fieldnames()
   available_fields <- unique(c(ProjectFields$original_field_name, 
                                ProjectFields$export_field_name, 
-                               MetaData$field_name[MetaData$field_type %in% c("calc", "file")]))
+                               MetaData$field_name[MetaData$field_type %in% c("calc", "file")], 
+                               REDCAP_SYSTEM_FIELDS))
   
   checkmate::assert_subset(x = fields, 
                            choices = available_fields, 

--- a/R/exportRecordsTyped.R
+++ b/R/exportRecordsTyped.R
@@ -296,6 +296,8 @@ exportRecordsTyped.redcapApiConnection <-
 
   checkmate::reportAssertions(coll)
   
+  fields <- fields[!fields %in% REDCAP_SYSTEM_FIELDS] # redcapDataStructures.R
+  
   .exportRecordsTyped_validateFieldForm(rcon = rcon, 
                                         fields = fields, 
                                         drop_fields = drop_fields, 

--- a/tests/testthat/test-11-recordsTyped-exportRecordsTyped.R
+++ b/tests/testthat/test-11-recordsTyped-exportRecordsTyped.R
@@ -197,3 +197,14 @@ test_that(
     expect_true(all(Rec$prereq_yesno %in% c("Yes", "No", NA)))
   }
 )
+
+#####################################################################
+# Avoid error on System Fields (Issue #102)                      ####
+
+test_that(
+  "Including system fields in 'fields' doesn't produce an error", 
+  {
+    expect_no_error(exportRecordsTyped(rcon, 
+                                       fields = REDCAP_SYSTEM_FIELDS))
+  }
+)

--- a/tests/testthat/test-11-recordsTyped-exportRecordsTyped.R
+++ b/tests/testthat/test-11-recordsTyped-exportRecordsTyped.R
@@ -204,7 +204,33 @@ test_that(
 test_that(
   "Including system fields in 'fields' doesn't produce an error", 
   {
-    expect_no_error(exportRecordsTyped(rcon, 
-                                       fields = REDCAP_SYSTEM_FIELDS))
+    # FIXME: This test would be better run on a project that has
+    #        repeating instruments and events, and possibly DAGs
+    # Four use cases from #102
+    
+    # 1. User requests no fields (fields = NULL) return all fields
+    #    This is covered in other tests.
+    
+    # 2. User requests only actual fields (no system fields in 'fields')
+    #    Return actual fields + system fields
+    
+    Rec <- exportRecordsTyped(rcon, 
+                              fields = "record_id")
+    expect_true("redcap_event_name" %in% names(Rec))
+    
+    # 3. User requests actual fields + system fields. 
+    #    Return only the requested fields
+    # FIXME: This test would be better if it had more system fields 
+    #        available in the project
+    
+    Rec <- exportRecordsTyped(rcon, 
+                              fields = c("record_id", "redcap_event_name"))
+    expect_true(all(c("record_id", "redcap_event_name") %in% names(Rec)))
+    # 4. User requests only system fields
+    #    Return only system fields
+    
+    Rec <- exportRecordsTyped(rcon, 
+                              fields = c("redcap_event_name"))
+    expect_true(names(Rec) == "redcap_event_name")
   }
 )

--- a/tests/testthat/test-11-recordsTyped-exportRecordsTypedOffline.R
+++ b/tests/testthat/test-11-recordsTyped-exportRecordsTypedOffline.R
@@ -278,3 +278,40 @@ test_that(
     expect_class(rec$date_dmy[1], "character")
   }
 )
+
+#####################################################################
+# Avoid error on System Fields (Issue #102)                      ####
+
+test_that(
+  "Including system fields in 'fields' doesn't produce an error", 
+  {
+    # FIXME: This test would be better run on a project that has
+    #        repeating instruments and events, and possibly DAGs
+    # Four use cases from #102
+    
+    # 1. User requests no fields (fields = NULL) return all fields
+    #    This is covered in other tests.
+    
+    # 2. User requests only actual fields (no system fields in 'fields')
+    #    Return actual fields + system fields
+    
+    Rec <- exportRecordsTyped(rcon_off, 
+                              fields = "record_id")
+    expect_true("redcap_event_name" %in% names(Rec))
+    
+    # 3. User requests actual fields + system fields. 
+    #    Return only the requested fields
+    # FIXME: This test would be better if it had more system fields 
+    #        available in the project
+    
+    Rec <- exportRecordsTyped(rcon_off, 
+                              fields = c("record_id", "redcap_event_name"))
+    expect_true(all(c("record_id", "redcap_event_name") %in% names(Rec)))
+    # 4. User requests only system fields
+    #    Return only system fields
+    
+    Rec <- exportRecordsTyped(rcon_off, 
+                              fields = c("redcap_event_name"))
+    expect_true(names(Rec) == "redcap_event_name")
+  }
+)


### PR DESCRIPTION
Implements and adds tests for the following use cases:

1. User requests no fields (fields = NULL); receives all fields (actual + system)
2. User requests actual fields; receives requested fields + system fields
3. User requests actual fields + system_fields; user receives only the requested fields from both
4. User requests only system_fields; user receives only the requested system fields

Caveat: I think this will work when DAGs get involved, but we haven't implemented that yet, so I have been unable to test. When we get into repeated instruments, we'll want to revisit these tests.  I've left FIXME: notes in those tests.