### PR TITLE
Issue 159 m choice cast

### DIFF
--- a/R/fieldCastingFunctions.R
+++ b/R/fieldCastingFunctions.R
@@ -391,7 +391,8 @@ guessDate <- function(data,
 
 mChoiceCast <- function(data, 
                         rcon, 
-                        style = "labelled")
+                        style = "labelled",
+                        drop_fields = TRUE)
 {
   ###################################################################
   # Check arguments
@@ -431,6 +432,20 @@ mChoiceCast <- function(data,
                   records_raw = Raw, 
                   checkbox_fieldname = i, 
                   style = style)
+  
+  # get the suffixed field names
+  fields_to_drop <- character()
+  for (i in checkbox_fields) {
+    fields <- FieldNames$export_field_name[FieldNames$original_field_name %in% i]
+    fields_to_drop <- c(fields_to_drop, fields)
+  }
+  
+  # if drop_fields is FALSE, keep suffixed field, else if drop_fields is TRUE (default) remove suffixed field
+  if (drop_fields == FALSE) {
+    data
+  } else {
+    data <- data[, !names(data) %in% fields_to_drop]
+  }
   
   data
 }

--- a/tests/testthat/test-11-records-mChoice.R
+++ b/tests/testthat/test-11-records-mChoice.R
@@ -47,6 +47,37 @@ test_that(
   }
 )
 
+# drop_fields tests
+columns_to_check <- c("prereq_checkbox___1","prereq_checkbox___2","prereq_checkbox___abc","prereq_checkbox___4","no_prereq_checkbox___1","no_prereq_checkbox___2","no_prereq_checkbox___3",
+                      "checkbox_test___x","checkbox_test___y","checkbox_test___z")
+
+# default drop_fields is TRUE
+test_that(
+  "mChoice drop_fields defaults to TRUE works to drop suffixed checkbox fields",
+  {
+    rec <- exportRecordsTyped(rcon) |> mChoiceCast(rcon, style="labelled")
+    expect_false(any(columns_to_check %in% colnames(rec)), "Expected column names are present in the data frame.")
+  }
+)
+
+# drop_fields=TRUE
+test_that(
+  "mChoice drop_fields defaults to TRUE works to drop suffixed checkbox fields",
+  {
+    rec <- exportRecordsTyped(rcon) |> mChoiceCast(rcon, style="labelled", drop_fields=TRUE)
+    expect_false(any(columns_to_check %in% colnames(rec)), "Expected column names are present in the data frame.")
+  }
+)
+
+# drop_fields = FALSE
+test_that(
+  "mChoice drop_fields defaults to TRUE works to drop suffixed checkbox fields",
+  {
+    rec <- exportRecordsTyped(rcon) |> mChoiceCast(rcon, style="labelled", drop_fields=FALSE)
+    expect_true(any(columns_to_check %in% colnames(rec)), "Expected column names are not present in the data frame.")
+  }
+)
+
 # Without Hmisc Tests
 detach("package:Hmisc", unload=TRUE)
 


### PR DESCRIPTION
Add a drop_fields argument to mChoice fields that defaults to TRUE and drops the component/suffixed checkbox field names.

When drop_fields = FALSE remove the suffixed field names from the data returned.

Closes #159 