### PR TITLE
Set up default timeout

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 ## 2.7.4
 
+* Timeout on connections defaults to 5m. 
 * Clearer error message on connection closed.
 * export/import handles the now and today validation words for dates and date/times.
 * unlockREDCap: major refactor / rewrite. Many edges cases handled gracefully with better error messaging. Now with less password requests.

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,9 +1,18 @@
 packageStartupMessage(
   "Welcome to redcapAPI.  Please Note:\n",
+  " - Unless previously set, the http request has been set to time out after 5 minutes.\n",
   " - 'exportBundle' has been made redundant. See ?redcapConnection for details about caching project data.")
 
 .onLoad <- function(libname,pkgname)
 {
+  # Set the time out to 5 minutes (300 seconds) 
+  # If a setting had already existed for timeout_ms, restore it.  
+  # We don't want to disrupt the user's settings
+  old <- httr::set_config(httr::timeout(300))
+  if (!is.null(old$options$timeout_ms) && old$options$timeout_ms != 3e+05){
+    httr::set_config(old)
+  }
+  
   options(redcap_api_url = character(0),
           redcap_error_handling = "null",
           redcap_bundle = 

--- a/tests/testthat/test-00-packageSetup.R
+++ b/tests/testthat/test-00-packageSetup.R
@@ -1,0 +1,65 @@
+context("Test package setup")
+
+test_that(
+  "Default timeout set to 5 minutes (300 seconds / 30,000 milliseconds)", 
+  {
+    old <- httr::set_config(httr::timeout(500))
+    
+    expect_equal(old$options$timeout_ms, 
+                 3e+05)
+    
+    httr::set_config(old)
+  }
+)
+
+
+test_that(
+  "Setting timeout on the connection object overrides the default", 
+  {
+    this_conn <- redcapConnection(url = rcon$url, 
+                                  token = rcon$token, 
+                                  config = httr::config(timeout_ms = 5e+05))
+    
+    default_response <- makeApiCall(rcon, 
+                                    body = list(content = "metadata", 
+                                                return = "csv", 
+                                                returnFormat = "csv"))
+    
+    custom_response <- makeApiCall(this_conn, 
+                                   body = list(content = "metadata", 
+                                               return = "csv", 
+                                               returnFormat = "csv"))
+    
+    expect_equal(default_response$request$options$timeout_ms, 
+                 3e+05)
+    expect_equal(custom_response$request$options$timeout_ms, 
+                 5e+05)
+    
+  }
+)
+
+test_that(
+  "Setting timeout on the function call overrides the default", 
+  {
+    this_conn <- redcapConnection(url = rcon$url, 
+                                  token = rcon$token, 
+                                  config = httr::config(timeout_ms = 5e+05))
+    
+    default_response <- makeApiCall(rcon, 
+                                    body = list(content = "metadata", 
+                                                return = "csv", 
+                                                returnFormat = "csv"))
+    
+    custom_response <- makeApiCall(this_conn, 
+                                   body = list(content = "metadata", 
+                                               return = "csv", 
+                                               returnFormat = "csv"), 
+                                   config = httr::config(timeout_ms = 4e+05))
+    
+    expect_equal(default_response$request$options$timeout_ms, 
+                 3e+05)
+    expect_equal(custom_response$request$options$timeout_ms, 
+                 4e+05)
+    
+  }
+)

--- a/tests/testthat/test-unlockREDCap.R
+++ b/tests/testthat/test-unlockREDCap.R
@@ -238,13 +238,14 @@ test_that(
     
     calls <- 0
     passwordFUN <- function(...) {calls <<- calls + 1; ""}
+    e <- new.env()
     
     expect_silent(unlockREDCap(
       c(rcon="TestRedcapAPI"), url, keyring="API_KEYs",
-      envir=1, passwordFUN=passwordFUN))
+      envir=e, passwordFUN=passwordFUN))
     
-    expect_true(exists("rcon"))
-    expect_class(rcon, "redcapApiConnection")
+    expect_true(exists("rcon", envir=e))
+    expect_class(e[["rcon"]], "redcapApiConnection")
     expect_true(calls == 0) # No password requests
   }
 )
@@ -262,11 +263,11 @@ test_that(
     
     m <- mock(TRUE)
     n <- mock(TRUE)
-    
+
     with_mocked_bindings(
       x <- unlockREDCap(
         c(rcon="George"), url, keyring="API_KEYs",
-        envir=1, passwordFUN=passwordFUN),
+        passwordFUN=passwordFUN),
       key_set_with_value = m,
       .connectAndCheck = n
     )


### PR DESCRIPTION
* Sets the default timeout to 5 minutes
* If a setting was made prior to loading the package, it will revert to that prior setting
* Tests provided that confirm the timeout can be overridden on either the connection object or the function call

This doesn't use the proposed `modifyList` strategy. Instead it uses the httr workflow. (the workflow itself is awkward, because you have to make a change in order to determine if something existed before, but we'd have to do that with the `modifyList` strategy anyway).