### PR TITLE
171 label event dag

### DIFF
--- a/R/exportRecordsTyped.R
+++ b/R/exportRecordsTyped.R
@@ -59,7 +59,10 @@
 #' @param cast A named \code{list} of user specified class casting functions. The
 #'   same named keys are supported as the na argument. The function will be 
 #'   provided the variables (x, field_name, coding). The function must return a
-#'   vector of logical matching the input length. See \code{\link{fieldValidationAndCasting}}
+#'   vector of logical matching the input length. See \code{\link{fieldValidationAndCasting}}.
+#'   The field type \code{system} may also be used to determine how the fields
+#'   \code{redcap_event_name}, \code{redcap_repeat_instrument}, and 
+#'   \code{redcap_data_access_group} are cast.
 #' @param assignment A named \code{list} of functions. These functions are provided, field_name,
 #'   label, description and field_type and return a list of attributes to assign
 #'   to the column. Defaults to creating a label attribute from the stripped

--- a/R/fieldCastingFunctions.R
+++ b/R/fieldCastingFunctions.R
@@ -582,15 +582,15 @@ mChoiceCast <- function(data,
   # Set system fields to text if the data sets needed to make the code books
   # is not present. (this is more common with offline connections)
   if (is.null(rcon$events())){
-    field_types[field_names %in% "redcap_event_name"] <- 
+    field_types[field_bases %in% "redcap_event_name"] <- 
       rep("text", 
-          sum(field_names %in% "redcap_event_name"))
+          sum(field_bases %in% "redcap_event_name"))
   }
   
   if (is.null(rcon$events())){
-    field_types[field_names %in% "redcap_data_access_group"] <- 
+    field_types[field_bases %in% "redcap_data_access_group"] <- 
       rep("text", 
-          sum(field_names %in% "redcap_data_access_group"))
+          sum(field_bases %in% "redcap_data_access_group"))
   }
   
   field_types

--- a/R/fieldValidationAndCasting.R
+++ b/R/fieldValidationAndCasting.R
@@ -308,7 +308,8 @@ raw_cast <- list(
   select             = NA,
   radio              = NA,
   dropdown           = NA,
-  sql                = NA
+  sql                = NA, 
+  system             = NA
 )
 
 #####################################################################
@@ -360,7 +361,8 @@ raw_cast <- list(
   select                   = castLabel,
   radio                    = castLabel,
   dropdown                 = castLabel,
-  sql                      = NA
+  sql                      = NA, 
+  system                   = castLabel
 )
 
 #####################################################################
@@ -425,7 +427,8 @@ raw_cast <- list(
   phone                    = as.character,
   zipcode                  = as.character, 
   slider                   = as.numeric,
-  sql                      = NA
+  sql                      = NA, 
+  system                   = castRaw
 )
 
 FIELD_TYPES <- c(

--- a/R/purgeRestoreProject.R
+++ b/R/purgeRestoreProject.R
@@ -253,7 +253,8 @@ purgeProject.redcapApiConnection <- function(object,
   
   if (records){
     RecordId <- exportRecordsTyped(object, 
-                                   fields = object$metadata()$field_name[1], 
+                                   fields = object$metadata()$field_name[1],
+                                   cast = list(system = castRaw),
                                    error_handling = error_handling, 
                                    config = config)
     

--- a/R/redcapConnection.R
+++ b/R/redcapConnection.R
@@ -342,6 +342,8 @@ print.redcapApiConnection <- function(x, ...){
 #'   Records can be read, or a \code{data.frame}. This should be the raw 
 #'   data as downloaded from the API, for instance. Using labelled or formatted
 #'   data is likely to result in errors when passed to other functions. 
+#' @param dags Either a \code{character} giving the file from which the 
+#'   Data Access Groups can be read, or a \code{data.frame}.
 #' @export
 
 offlineConnection <- function(meta_data = NULL, 

--- a/R/redcapConnection.R
+++ b/R/redcapConnection.R
@@ -355,7 +355,8 @@ offlineConnection <- function(meta_data = NULL,
                               project_info = NULL, 
                               file_repo = NULL, 
                               repeat_instrument = NULL,
-                              records = NULL){
+                              records = NULL, 
+                              dags = NULL){
   ###################################################################
   # Argument Validation 
   coll <- checkmate::makeAssertCollection()
@@ -481,6 +482,16 @@ offlineConnection <- function(meta_data = NULL,
     add = coll
   )
   
+  checkmate::assert(
+    checkmate::check_character(x = dags, 
+                               len = 1, 
+                               null.ok = TRUE), 
+    checkmate::check_data_frame(x = dags, 
+                                null.ok = TRUE), 
+    .var.name = "dags", 
+    add = coll
+  )
+  
   checkmate::reportAssertions(coll)
   
   ###################################################################
@@ -541,6 +552,11 @@ offlineConnection <- function(meta_data = NULL,
                                   add = coll)
   }
   
+  if (is.character(dags)){
+    checkmate::assert_file_exists(x = dags, 
+                                  add = coll)
+  }
+  
   checkmate::reportAssertions(coll)
   
   ###################################################################
@@ -584,6 +600,11 @@ offlineConnection <- function(meta_data = NULL,
       validateRedcapData(data = .offlineConnection_readFile(instruments), 
                          redcap_data = REDCAP_INSTRUMENT_STRUCTURE)
     }
+  
+  this_dag <- 
+    validateRedcapData(data = .offlineConnection_readFile(dags), 
+                       redcap_data = REDCAP_DAG_STRUCTURE)
+  
   this_record <- .offlineConnection_readFile(records)
   
   rc <- 
@@ -672,6 +693,12 @@ offlineConnection <- function(meta_data = NULL,
       refresh_repeatInstrumentEvent = function(x) {this_project <<- validateRedcapData(data = .offlineConnection_readFile(x), 
                                                                                        redcap_data = REDCAP_REPEAT_INSTRUMENT_STRUCTURE)},
       
+      dags = function(){ this_dag }, 
+      has_dags = function() !is.null(this_dag), 
+      flush_dags = function() this_dag <<- NULL, 
+      refresh_dags = function(x) {this_dag <<- validateRedcapData(data = .offlineConnection_readFile(dags), 
+                                                                  redcap_data = REDCAP_DAG_STRUCTURE)},
+      
       records = function(){ this_record },
       has_records = function() !is.null(this_record),
       flush_records = function() this_record <<- NULL,
@@ -704,7 +731,8 @@ print.redcapOfflineConnection <- function(x, ...){
         sprintf("Field Names : %s", is_cached(x$has_fieldnames())), 
         sprintf("Mapping     : %s", is_cached(x$has_mapping())),
         sprintf("Repeat Inst.: %s", is_cached(x$has_repeatInstrumentEvent())),
-        sprintf("Users       : %s", is_cached(x$has_users())), 
+        sprintf("Users       : %s", is_cached(x$has_users())),
+        sprintf("DAGs        : %s", is_cached(x$has_dags())),
         sprintf("Version     : %s", is_cached(x$has_version())), 
         sprintf("Project Info: %s", is_cached(x$has_projectInformation())), 
         sprintf("File Repo   : %s", is_cached(x$has_fileRepository())))

--- a/man/exportRecordsTyped.Rd
+++ b/man/exportRecordsTyped.Rd
@@ -121,7 +121,10 @@ are not identified as NA will be passed to validation functions.}
 \item{cast}{A named \code{list} of user specified class casting functions. The
 same named keys are supported as the na argument. The function will be 
 provided the variables (x, field_name, coding). The function must return a
-vector of logical matching the input length. See \code{\link{fieldValidationAndCasting}}}
+vector of logical matching the input length. See \code{\link{fieldValidationAndCasting}}.
+The field type \code{system} may also be used to determine how the fields
+\code{redcap_event_name}, \code{redcap_repeat_instrument}, and 
+\code{redcap_data_access_group} are cast.}
 
 \item{assignment}{A named \code{list} of functions. These functions are provided, field_name,
 label, description and field_type and return a list of attributes to assign

--- a/man/fieldValidationAndCasting.Rd
+++ b/man/fieldValidationAndCasting.Rd
@@ -22,7 +22,7 @@
 \alias{na_values}
 \title{Helper functions for \code{exportRecordsTyped} Validation and Casting}
 \format{
-An object of class \code{list} of length 19.
+An object of class \code{list} of length 20.
 }
 \usage{
 isNAorBlank(x, ...)

--- a/man/redcapConnection.Rd
+++ b/man/redcapConnection.Rd
@@ -30,7 +30,8 @@ offlineConnection(
   project_info = NULL,
   file_repo = NULL,
   repeat_instrument = NULL,
-  records = NULL
+  records = NULL,
+  dags = NULL
 )
 
 \method{print}{redcapOfflineConnection}(x, ...)
@@ -103,6 +104,9 @@ Note: The REDCap GUI doesn't offer a download file of these settings
 Records can be read, or a \code{data.frame}. This should be the raw 
 data as downloaded from the API, for instance. Using labelled or formatted
 data is likely to result in errors when passed to other functions.}
+
+\item{dags}{Either a \code{character} giving the file from which the 
+Data Access Groups can be read, or a \code{data.frame}.}
 }
 \description{
 Creates an object of class \code{redcapApiConnection} for 

--- a/tests/testthat/test-11-records-deleteRecords.R
+++ b/tests/testthat/test-11-records-deleteRecords.R
@@ -1,7 +1,8 @@
 context("deleteRecords")
 
 test_that("records can be deleted",{
-  rec <- exportRecordsTyped(rcon, forms = "fieldtovar_datetimes", mChoice=FALSE)
+  rec <- exportRecordsTyped(rcon, forms = "fieldtovar_datetimes", mChoice=FALSE, 
+                            cast = list(system = castRaw))
   rows <- nrow(rec)
   
   rec <- rbind(rec[1,], rec[1,])
@@ -20,7 +21,8 @@ test_that("error when trying to delete something that doesn't exist",{
 })
 
 test_that("arm restrictions are honored",{
-  rec <- exportRecordsTyped(rcon, forms = "fieldtovar_datetimes", mChoice=FALSE)
+  rec <- exportRecordsTyped(rcon, forms = "fieldtovar_datetimes", mChoice=FALSE, 
+                            cast = list(system = castRaw))
   rows <- nrow(rec)
   
   rec <- rec[1:2,]

--- a/tests/testthat/test-11-records-importRecords.R
+++ b/tests/testthat/test-11-records-importRecords.R
@@ -133,7 +133,8 @@ test_that(
 test_that(
   "import with Auto Numbering", 
   {
-    Records <- exportRecordsTyped(rcon, mChoice = FALSE)
+    Records <- exportRecordsTyped(rcon, mChoice = FALSE, 
+                                  cast = list(system = castRaw))
     nrow(Records)
     OneRecord <- Records[1,]
     
@@ -144,13 +145,13 @@ test_that(
                            returnContent = 'auto_ids',
                            force_auto_number = TRUE)
     
-    expect_equal(NewId$id, next_record_id)
+    expect_true(NewId$id > nrow(Records))
     
     After <- exportRecordsTyped(rcon)
     
-    expect_equal(nrow(Records) + 1, nrow(After))
+    expect_true(nrow(Records) < nrow(After))
     
-    deleteRecords(rcon, records = next_record_id)
+    deleteRecords(rcon, records = max(After$record_id))
   }
 )
 
@@ -168,7 +169,7 @@ test_that(
     OrigMeta$text_validation_min[w_var] <- "today"
     importMetaData(rcon, OrigMeta)
     
-    NewData <- exportRecordsTyped(rcon)
+    NewData <- exportRecordsTyped(rcon, cast = list(system = castRaw))
     NewData <- NewData[NewData$record_id == 10, 
                        c("record_id", "redcap_event_name", 
                          "redcap_repeat_instrument", "redcap_repeat_instance", 
@@ -185,7 +186,8 @@ test_that(
     OrigMeta$text_validation_max[w_var] <- "today"
     importMetaData(rcon, OrigMeta)
     
-    NewData <- exportRecordsTyped(rcon)
+    NewData <- exportRecordsTyped(rcon, 
+                                  cast = list(system = castRaw))
     NewData <- NewData[NewData$record_id == 10, 
                        c("record_id", "redcap_event_name", 
                          "redcap_repeat_instrument", "redcap_repeat_instance", 
@@ -202,7 +204,8 @@ test_that(
     OrigMeta$text_validation_min[w_var] <- "now"
     importMetaData(rcon, OrigMeta)
     
-    NewData <- exportRecordsTyped(rcon)
+    NewData <- exportRecordsTyped(rcon, 
+                                  cast = list(system = castRaw))
     NewData <- NewData[NewData$record_id == 10, 
                        c("record_id", "redcap_event_name", 
                          "redcap_repeat_instrument", "redcap_repeat_instance", 
@@ -219,7 +222,8 @@ test_that(
     OrigMeta$text_validation_max[w_var] <- "now"
     importMetaData(rcon, OrigMeta)
     
-    NewData <- exportRecordsTyped(rcon)
+    NewData <- exportRecordsTyped(rcon, 
+                                  cast = list(system = castRaw))
     NewData <- NewData[NewData$record_id == 10, 
                        c("record_id", "redcap_event_name", 
                          "redcap_repeat_instrument", "redcap_repeat_instance", 

--- a/tests/testthat/test-11-recordsTyped-exportRecordsTyped.R
+++ b/tests/testthat/test-11-recordsTyped-exportRecordsTyped.R
@@ -54,14 +54,15 @@ test_that(
 test_that(
   "Data returned only for designated event",
   {
-    Records <- exportRecordsTyped(rcon, events = "event_1_arm_1")
+    Records <- exportRecordsTyped(rcon, events = "event_1_arm_1", 
+                                  cast = list(system = castRaw))
     expect_true(all(Records$redcap_event_name %in% "event_1_arm_1"))
   }
 )
 
 
-###################################################################
-# Test attribute assignments versus defaults
+#####################################################################
+# Test attribute assignments versus defaults                     ####
 rec <- exportRecordsTyped(rcon)
 test_that(
   "HTML and Unicode is stripped by default",
@@ -74,8 +75,8 @@ test_that(
 )
 rm(rec)
 
-###################################################################
-# NA Detection
+#####################################################################
+# NA Detection                                                   ####
 test_that(
   "NA can be override for user definitions",
   {
@@ -84,8 +85,8 @@ test_that(
   }
 )
 
-###################################################################
-# Validation
+#####################################################################
+# Validation                                                     ####
 test_that(
   "Custom validation works",
   {
@@ -122,8 +123,8 @@ test_that(
   }
 )
 
-###################################################################
-# Casting
+#####################################################################
+# Casting                                                        ####
 test_that(
   "Dates can be cast using as.Date",
   {
@@ -142,7 +143,7 @@ test_that(
 )
 
 #####################################################################
-# Export calculated fields
+# Export calculated fields                                       ####
 
 test_that(
   "Calculated fields are exported", 
@@ -157,7 +158,7 @@ test_that(
 )
 
 #####################################################################
-# Export for a single record
+# Export for a single record                                     ###f
 
 test_that(
   "Export succeeds for a single record", 
@@ -185,7 +186,7 @@ test_that(
 )
 
 #####################################################################
-# Yes/No fields are cast properly
+# Yes/No fields are cast properly                                ####
 
 test_that(
   "Yes/No fields are labelled correctly", 
@@ -285,5 +286,61 @@ test_that(
     expect_error(exportRecordsTyped(rcon, 
                                     api_param = list(fields = "this_wont_work_abc123")), 
                  "The following values in the parameter \"fields\" are not valid")
+  }
+)
+
+
+#####################################################################
+# Casting System Fields                                          ####
+
+test_that(
+  "System fields cast as labelled", 
+  {
+    Rec <- exportRecordsTyped(rcon)
+    
+    # redcap_event_name
+    Event <- rcon$events()
+    Arm <- rcon$arms()
+    
+    EventArm <- merge(Event, 
+                      Arm, 
+                      by = "arm_num", 
+                      all.x = TRUE)
+    
+    levels <- sprintf("%s (Arm %s: %s)", 
+                      EventArm$event_name, 
+                      EventArm$arm_num, 
+                      EventArm$name)
+    
+    expect_equal(levels(Rec$redcap_event_name), 
+                 levels)
+    
+    # redcap_repeat_instrument
+    Instrument <- rcon$instruments()
+    
+    expect_equal(levels(Rec$redcap_repeat_instrument), 
+                 rcon$instruments()$instrument_label)
+    
+    # redcap_data_access_group
+    # FIXME: Add tests for DAGs
+  }
+)
+
+test_that(
+  "System fields cast as raw", 
+  {
+    Rec <- exportRecordsTyped(rcon, 
+                              cast = list(system = castRaw))
+    
+    # redcap_event_name
+    expect_true(all(Rec$redcap_event_name %in% 
+                      rcon$events()$unique_event_name))
+    
+    # redcap_repeat_instrument
+    expect_true(all(Rec$redcap_repeat_instrument %in%
+                       c(rcon$instruments()$instrument_name, NA_character_)))
+    
+    # redcap_data_access_group
+    # FIXME: Add tests for DAGs
   }
 )

--- a/tests/testthat/test-11-recordsTyped-exportRecordsTypedOffline.R
+++ b/tests/testthat/test-11-recordsTyped-exportRecordsTypedOffline.R
@@ -62,7 +62,9 @@ test_that(
 test_that(
   "Data returned only for designated event",
   {
-    Records <- exportRecordsTyped(rcon_off, events = "event_1_arm_1")
+    Records <- exportRecordsTyped(rcon_off, 
+                                  events = "event_1_arm_1", 
+                                  cast = list(system = castRaw))
     expect_true(all(Records$redcap_event_name %in% "event_1_arm_1"))
   }
 )

--- a/tests/testthat/test-prepUserImportData.R
+++ b/tests/testthat/test-prepUserImportData.R
@@ -27,6 +27,7 @@ test_that(
 test_that(
   "Return an error if data is not a data frame",
   {
+    local_reproducible_output(width = 200)
     expect_error(prepUserImportData("not data", 
                                     rcon = rcon), 
                  "'data': Must be of type 'data.frame'")
@@ -42,6 +43,7 @@ test_that(
 test_that(
   "Return an error if rcon is not a redCapConnection", 
   {
+    local_reproducible_output(width = 200)
     expect_error(prepUserImportData(User, 
                                     rcon = "not a connection"), 
                  "Must inherit from class 'redcapConnection'")
@@ -51,6 +53,7 @@ test_that(
 test_that(
   "Return an error if consolidate is not logical(1)", 
   {
+    local_reproducible_output(width = 200)
     expect_error(prepUserImportData(User, 
                                     rcon = rcon, 
                                     consolidate = "TRUE"), 


### PR DESCRIPTION
* Adds a "system" field type that casts `redcap_event_name`, `redcap_repeat_instrument` and `redcap_data_access_group`
* Maps the coded and labeled values for these fields into a code book to make them respond to castLabel and castRaw
* Adds dags to the redcapOfflineConnection
* Modifies tests to pass with the new system field casting