### PR TITLE
Issue 206 import user assigned to role

### DIFF
--- a/R/importUserRoleAssignments.R
+++ b/R/importUserRoleAssignments.R
@@ -133,6 +133,7 @@ importUserRoleAssignments.redcapApiConnection <- function(rcon,
   
   if (refresh){
     rcon$refresh_user_role_assignment()
+    rcon$refresh_users()
   }
   
   message(sprintf("User-Role Assignments Added/Updated: %s", 

--- a/R/importUserRoles.R
+++ b/R/importUserRoles.R
@@ -134,7 +134,7 @@ importUserRoles.redcapApiConnection <- function(rcon,
   }
   
   if (refresh){
-    # FIXME: set up the refresh
+    rcon$refresh_user_roles()
   }
   
   message(sprintf("User Roles Added/Modified: %s", as.character(response)))

--- a/R/importUsers.R
+++ b/R/importUsers.R
@@ -41,6 +41,13 @@
 #' be exported via \code{exportUsers}. With \code{consolidate = TRUE}, these 
 #' settings will be consolidated into the text string expected by the API. 
 #' 
+#' The REDCap API does not natively allow for modifying the rights of a user
+#' that is part of a User Role. When an attempt to modify the rights of a 
+#' user in a User Role is made with this package, the user will be removed
+#' from the User Role, the rights modified, and then the User Role restored. 
+#' This is done silently: be aware that modifications to a user's rights 
+#' may not have an impact while the User Role is assigned.
+#' 
 #' @section Limitations: 
 #' 
 #' When exporting via CSV, (as redcapAPI does by default) it appears that 
@@ -156,7 +163,7 @@ importUsers.redcapApiConnection <- function(rcon,
   
   if (user_conflict_exists){
     importUserRoleAssignments(rcon, 
-                              data = OrigUserRoleAssign)
+                              data = OrigUserRoleAssign[1:2])
   }
   
   if (refresh){
@@ -184,7 +191,7 @@ importUsers.redcapApiConnection <- function(rcon,
                                               nrow(UsersWithConflict))
     
     importUserRoleAssignments(rcon, 
-                              data = UsersWithConflict)
+                              data = UsersWithConflict[1:2])
   }
   
   user_conflict_exists

--- a/man/importUsers.Rd
+++ b/man/importUsers.Rd
@@ -66,7 +66,14 @@ converted to the numeric equivalent.
 
 It is also permissible to use a column for each form individually, as can
 be exported via \code{exportUsers}. With \code{consolidate = TRUE}, these 
-settings will be consolidated into the text string expected by the API.
+settings will be consolidated into the text string expected by the API. 
+
+The REDCap API does not natively allow for modifying the rights of a user
+that is part of a User Role. When an attempt to modify the rights of a 
+user in a User Role is made with this package, the user will be removed
+from the User Role, the rights modified, and then the User Role restored. 
+This is done silently: be aware that modifications to a user's rights 
+may not have an impact while the User Role is assigned.
 }
 \section{Limitations}{
  

--- a/tests/testthat/test-103-userRoleAssignmentMethods-Functionality.R
+++ b/tests/testthat/test-103-userRoleAssignmentMethods-Functionality.R
@@ -61,3 +61,48 @@ test_that(
                    "User Roles Deleted: 1")
   }
 )
+
+
+test_that(
+  "Import User Changes when User is Assigned a Role", # Issue 206
+  {
+    UserRole <- data.frame(role_label = "Temporary Role", 
+                           design = 1, 
+                           user_rights = 1, 
+                           reports = 1)
+    
+    importUserRoles(rcon, data = UserRole)
+    
+    THIS_ROLE <- rcon$user_roles()$unique_role_name[1]
+    
+    importUserRoleAssignments(rcon, 
+                              data = data.frame(username = EXPENDABLE_USER, 
+                                                unique_role_name = THIS_ROLE))
+    
+    importUsers(rcon, data = data.frame(username = EXPENDABLE_USER, 
+                                        data_access_groups = 1))
+    
+    NewUser <- exportUsers(rcon, labels = FALSE)
+    NewUser <- NewUser[NewUser$username == EXPENDABLE_USER, ]
+    
+    # The user is still assigned to the role, so the role permission should
+    # be displayed (no access)
+    expect_equal(NewUser$data_access_groups, 0)
+    
+    importUserRoleAssignments(rcon, 
+                              data = data.frame(username = "bstat_api_user", 
+                                                unique_role_name = NA_character_))
+    
+    NewUser <- exportUsers(rcon, labels = FALSE)
+    NewUser <- NewUser[NewUser$username == EXPENDABLE_USER, ]
+    
+    # Now that the role has been unassigned, the permission we uploaded (access)
+    # should be returned.
+    expect_equal(NewUser$data_access_groups, 1)
+    
+    importUsers(rcon, data = data.frame(username = EXPENDABLE_USER, 
+                                        data_access_groups = 0))
+    
+    deleteUserRoles(rcon, user_roles = THIS_ROLE) 
+  }
+)


### PR DESCRIPTION
Automates updating user rights when a user is actively assigned a user role.  This is accomplished by

* Storing the user role assignment
* Remove the user role assignment
* Applying the user rights via importUsers
* Restore the role assignment

Description of this is added to the documentation with clarification that changes to user rights assigned via roles preempt rights assigned to the user.