### PR TITLE
set reproducible output width for a few tests

### DIFF
--- a/tests/testthat/test-103-userRoleAssignmentMethods-ArgumentValidation.R
+++ b/tests/testthat/test-103-userRoleAssignmentMethods-ArgumentValidation.R
@@ -77,6 +77,7 @@ test_that(
 test_that(
   "Return an error if there are duplicate usernames", 
   {
+    local_reproducible_output(width = 200)
     the_user <- rcon$users()$username[1]
     NewRole <- data.frame(unique_role_name = NA_character_, 
                            role_label = "Temporary role", 

--- a/tests/testthat/test-200-exportTypedRecords-ArgumentValidation.R
+++ b/tests/testthat/test-200-exportTypedRecords-ArgumentValidation.R
@@ -219,6 +219,7 @@ test_that(
 test_that(
   "exportRecordsTyped expects single logical for filter_empty_rows", 
   {
+    local_reproducible_output(width = 200)
     expect_error(exportRecordsTyped(rcon, filter_empty_rows=1),
                  "Variable 'filter_empty_rows': Must be of type 'logical'")
     expect_error(exportRecordsTyped(rcon, filter_empty_rows=c(TRUE, FALSE)),
@@ -260,16 +261,5 @@ test_that(
     local_reproducible_output(width = 200)
     expect_error(exportRecordsTyped(rcon,events='doesntexist'),
                  "'events'[:] Must be a subset of")
-  }
-)
-
-
-test_that(
-  "exportRecordsTyped expects single logical for filter_empty_rows", 
-  {
-    expect_error(exportRecordsTyped(rcon, filter_empty_rows=1),
-      "Variable 'filter_empty_rows': Must be of type 'logical'")
-    expect_error(exportRecordsTyped(rcon, filter_empty_rows=c(TRUE, FALSE)),
-      "Variable 'filter_empty_rows': Must have length 1")
   }
 )

--- a/tests/testthat/test-301-fileMethods-Functionality.R
+++ b/tests/testthat/test-301-fileMethods-Functionality.R
@@ -5,6 +5,7 @@ local_file <- test_path("testdata", "FileForImportExportTesting.txt")
 test_that(
   "import, export, and delete a file in a longitudinal project",
   {
+    local_reproducible_output(width = 200)
     expect_message(
       importFiles(rcon,
                   file = local_file,
@@ -86,6 +87,7 @@ importRecords(rcon,
 test_that(
   "import, export, and delete a file in a longitudinal project",
   {
+    local_reproducible_output(width = 200)
     expect_message(
       importFiles(rcon,
                   file = local_file,


### PR DESCRIPTION
Whoops. I usually catch these in testing. 

If you ever learn of a way to set the terminal width for the full duration of the test suite, I'd love that.  

I picked up a few more tests that would benefit from `local_reproducible_output` by setting my terminal width to one character and running the tests.