### PR TITLE
validate imports for fixed decimal place numbers (and tests)

### DIFF
--- a/R/validateImport.R
+++ b/R/validateImport.R
@@ -130,7 +130,7 @@ validateImport <- function(data, meta_data, logfile = "")
       }
     }
     
-    if (field_type %in% c("float", "integer", "number", "number_1dp"))
+    if (field_type %in% c("float", "integer", "number"))
       field_type <- "numeric"
   
     data[[field_name]] <- 
@@ -253,6 +253,36 @@ validateImport <- function(data, meta_data, logfile = "")
           validate_import_phone(x = data[[field_name]],
                                 field_name = field_name,
                                 logfile = logfile),
+        "number_1dp" = 
+          validate_import_ndp(x = data[[field_name]],
+                              field_name = field_name,
+                              field_min = field_min,
+                              field_max = field_max,
+                              logfile = logfile, 
+                              ndp = 1), 
+        "number_2dp" = 
+          validate_import_ndp(x = data[[field_name]],
+                              field_name = field_name,
+                              field_min = field_min,
+                              field_max = field_max,
+                              logfile = logfile, 
+                              ndp = 2), 
+        "number_1dp_comma_decimal" = 
+          validate_import_ndp(x = data[[field_name]],
+                              field_name = field_name,
+                              field_min = field_min,
+                              field_max = field_max,
+                              logfile = logfile, 
+                              ndp = 1, 
+                              comma = TRUE), 
+        "number_2dp_comma_decimal" = 
+          validate_import_ndp(x = data[[field_name]],
+                              field_name = field_name,
+                              field_min = field_min,
+                              field_max = field_max,
+                              logfile = logfile, 
+                              ndp = 2,
+                              comma = TRUE), 
         data[[field_name]]
       )
   }

--- a/R/validateImport_methods.R
+++ b/R/validateImport_methods.R
@@ -368,6 +368,56 @@ validate_import_numeric <- function(x, field_name, field_min, field_max, logfile
   x
 }
 
+# validate_import_number_dp -------------------------------------------
+# Tests to perform
+# * values that can be coerced to numeric pass.
+# * NA passes
+# * Values that cannot be coerced to numeric produce a message
+# * values less than field_min produce a message
+# * values greater than field_max produce a message
+validate_import_ndp <- function(x, field_name, field_min, field_max, logfile, 
+                                    ndp, comma = FALSE)
+{
+  suppressWarnings(num_check <- as.numeric(x))
+  w <- which(is.na(num_check) & !x %in% c('', NA))
+  
+  suppressWarnings({
+    if (!is.numeric(x)) x <- as.numeric(x)
+    field_min <- as.numeric(field_min)
+    field_max <- as.numeric(field_max)
+  })
+  
+  print_validation_message(
+    field_name,
+    indices = which(x < field_min),
+    message = paste0("Value(s) are less than the stated minimum: ",
+                     field_min),
+    logfile = logfile
+  )
+  
+  print_validation_message(
+    field_name,
+    indices = which(x > field_max),
+    message = paste0("Value(s) are greater than the stated maximum: ",
+                     field_max),
+    logfile = logfile
+  )
+  
+  print_validation_message(
+    field_name,
+    indices = w,
+    message = paste0("Value(s) must be numeric or coercible to numeric.\n",
+                     "Values not imported"),
+    logfile = logfile
+  )
+  
+  x[!is.na(x)] <- trimws(format(round(x[!is.na(x)], ndp), 
+                                nsmall = ndp, 
+                                decimal.mark = if (comma) "," else "."))
+  
+  x
+}
+
 # validate_import_zipcode -------------------------------------------
 # Tests to run
 # * values in 12345 and 12345-1234 format pass

--- a/tests/testthat/test-109-instrumentMethods-Functionality.R
+++ b/tests/testthat/test-109-instrumentMethods-Functionality.R
@@ -53,7 +53,12 @@ Mapping <- data.frame(arm_num = c(1, 1, 1, 2, 2, 2),
 RecordToImport <- test_redcapAPI_Data[test_redcapAPI_Data$record_id %in% 1:3, ]
 RecordToImport <- RecordToImport[is.na(RecordToImport$repeat_question_1), ]
 RecordToImport <- RecordToImport[names(RecordToImport) %in% rcon$metadata()$field_name]
-RecordToImport <- castForImport(RecordToImport, rcon)
+# castForImport only needed until 3.0.0
+RecordToImport <- castForImport(RecordToImport, rcon, 
+                                cast = list(number_1dp = as.numeric, 
+                                            number_2dp = as.numeric, 
+                                            number_1dp_comma_decimal = as.numeric, 
+                                            number_2dp_comma_decimal = as.numeric))
 importRecords(rcon, 
               data = RecordToImport)
 

--- a/tests/testthat/test-200-exportTypedRecords-Functionality.R
+++ b/tests/testthat/test-200-exportTypedRecords-Functionality.R
@@ -43,7 +43,12 @@ importMappings(rcon,
 
 ImportData <- test_redcapAPI_Data[names(test_redcapAPI_Data) %in% MetaData$field_name]
 ImportData <- ImportData[!is.na(ImportData$email_test), ]
-ImportData <- castForImport(ImportData, rcon)
+# castForImport only needed until 3.0.0
+ImportData <- castForImport(ImportData, rcon, 
+                            cast = list(number_1dp = as.numeric, 
+                                        number_2dp = as.numeric, 
+                                        number_1dp_comma_decimal = as.numeric, 
+                                        number_2dp_comma_decimal = as.numeric))
 
 
 importRecords(rcon, 

--- a/tests/testthat/test-201-exportTypedRecords-withDAGs.R
+++ b/tests/testthat/test-201-exportTypedRecords-withDAGs.R
@@ -6,7 +6,11 @@ context("Export Typed Records with DAGs Functionality")
 ImportData <- exportRecordsTyped(rcon, 
                                  cast = raw_cast)
 ImportData <- castForImport(ImportData, 
-                            rcon)
+                            rcon, 
+                            cast = list(number_1dp = as.numeric, 
+                                        number_2dp = as.numeric, 
+                                        number_1dp_comma_decimal = as.numeric, 
+                                        number_2dp_comma_decimal = as.numeric))
 
 #####################################################################
 # Create DAGs to use in testing                                  ####

--- a/tests/testthat/test-204-exportTypedRecords-withRepeatingInstruments.R
+++ b/tests/testthat/test-204-exportTypedRecords-withRepeatingInstruments.R
@@ -27,8 +27,13 @@ RepeatInst <- data.frame(event_name = "event_1_arm_1",
 importRepeatingInstrumentsEvents(rcon, 
                                  data = RepeatInst)
 
-ImportData <- castForImport(test_redcapAPI_Data, 
-                            rcon)
+# castForImport only needed until 3.0.0
+ImportData <- castForImport(test_redcapAPI_Data,
+                            rcon,
+                            cast = list(number_1dp = as.numeric,
+                                        number_2dp = as.numeric,
+                                        number_1dp_comma_decimal = as.numeric,
+                                        number_2dp_comma_decimal = as.numeric))
 
 importRecords(rcon, ImportData)
 

--- a/tests/testthat/test-903-validateImport_methods.R
+++ b/tests/testthat/test-903-validateImport_methods.R
@@ -1240,3 +1240,48 @@ test_that(
     )
   }
 )
+
+test_that(
+  "Validate number with fixed decimal places (number_1dp, etc)", 
+  {
+    # number_1dp
+    expect_equal(validate_import_ndp(c(23, pi), 
+                                     field_name = "number_1dp", 
+                                     field_min = 0, 
+                                     field_max = 100, 
+                                     logfile = "", 
+                                     ndp = 1, 
+                                     comma = FALSE), 
+                 c("23.0", "3.1"))
+    
+    # number_2dp
+    expect_equal(validate_import_ndp(c(23, pi), 
+                                     field_name = "number_1dp", 
+                                     field_min = 0, 
+                                     field_max = 100, 
+                                     logfile = "", 
+                                     ndp = 2, 
+                                     comma = FALSE), 
+                 c("23.00", "3.14"))
+    
+    # number_1dp_comma
+    expect_equal(validate_import_ndp(c(23, pi), 
+                                     field_name = "number_1dp", 
+                                     field_min = 0, 
+                                     field_max = 100, 
+                                     logfile = "", 
+                                     ndp = 1, 
+                                     comma = TRUE), 
+                 c("23,0", "3,1"))
+    
+    # number_2dp_comma
+    expect_equal(validate_import_ndp(c(23, pi), 
+                                     field_name = "number_1dp", 
+                                     field_min = 0, 
+                                     field_max = 100, 
+                                     logfile = "", 
+                                     ndp = 2, 
+                                     comma = TRUE), 
+                 c("23,00", "3,14"))
+  }
+)


### PR DESCRIPTION
validates imports for number_1dp, number_2dp, number_1dp_comma_decimal, and number_2dp_comma_decimal. 

Tests added for validate_import_methods with these new methods. 

Resolves Issue #217 