### PR TITLE
Issue 228 import missing check

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -17,6 +17,7 @@ A future release of version 3.0.0 will introduce several breaking changes!
 * Fixed issue in importUsers where existing roles might get dropped on an update. Now handles the multiple API calls seemlessly to properly handle user roles.
 * Fixed issue with decimal validation.
 * Added renameRecord function.
+* Fixed issue with preserving missing values in preparing checkbox fields for import
 
 ## 2.7.5
 

--- a/R/fieldValidationAndCasting.R
+++ b/R/fieldValidationAndCasting.R
@@ -147,7 +147,9 @@ castRaw <- function(x, field_name, coding){
   
   raw <- 
     if (grepl(".*___(.*)", field_name)){
-      as.character((x %in% getCheckedValue(coding, field_name)) + 0L)
+      ifelse(!is.na(x), 
+             as.character((x %in% getCheckedValue(coding, field_name)) + 0L), 
+             NA)
     } else {
       code_match <- getCodingIndex(x, coding)
       unname(coding[code_match])

--- a/R/fieldValidationAndCasting.R
+++ b/R/fieldValidationAndCasting.R
@@ -216,7 +216,11 @@ castCheckCode <- function(x, field_name, coding){
 
 castCheckForImport <- function(checked = c("Checked", "1")){
   function(x, coding, field_name){
-    (x %in% checked) + 0L
+    is_na <- is.na(x)
+    
+    out <- (x %in% checked) + 0L
+    out[is_na] <- NA
+    out
   }
 }
 

--- a/tests/testthat/test-053-fieldValidationAndCasting.R
+++ b/tests/testthat/test-053-fieldValidationAndCasting.R
@@ -547,6 +547,13 @@ test_that(
     
     expect_equal(castCheckForImport("0")(x), 
                  c(0, 0, 0, 0, 0, 0, 1))
+    
+    # preserve NA values
+    
+    x[c(2, 4)] <- rep(NA, 2)
+    
+    expect_equal(castCheckForImport()(x), 
+                 c(0, NA, 0, NA, 1, 1, 0))
   }
 )
 

--- a/tests/testthat/test-053-fieldValidationAndCasting.R
+++ b/tests/testthat/test-053-fieldValidationAndCasting.R
@@ -375,6 +375,13 @@ test_that(
     expect_equal(castRaw(x, "field_name", coding), 
                  c(1, 1, 2, 2, 3, 3, -4, -4, 0, 0, 
                    NA))
+    
+    
+    # A checkbox with missing values preserves the missing values (See Issue 228)
+    x <- c("0", NA, "1")
+    coding <- c(Guitar = "x", Ukulele = "y", Mandolin = "z")
+    expect_equal(castRaw(x, "field___x", coding), 
+                 c(0, NA, 1))
   }
 )
 

--- a/tests/testthat/test-251-castForImport.R
+++ b/tests/testthat/test-251-castForImport.R
@@ -703,7 +703,7 @@ test_that(
 test_that(
   "only requested fields are recast", 
   {
-    Records <- data.frame(checkbox_test___x = c("0", "", "", "0"), 
+    Records <- data.frame(checkbox_test___x = c("0", "", "1", "0"), 
                           checkbox_test___y = c("y", "y", "", "y"))
     
     ForImport <- castForImport(Records, 
@@ -711,7 +711,7 @@ test_that(
                                fields = "checkbox_test___x",
                                cast = list(checkbox = castCheckForImport(checked = "0")))
     expect_equal(ForImport$checkbox_test___x, 
-                 c(1, 0, 0, 1))
+                 c(1, NA, 0, 1))
     expect_equal(ForImport$checkbox_test___y, 
                  c("y", "y", "", "y"))
   }

--- a/tests/testthat/test-251-castForImport.R
+++ b/tests/testthat/test-251-castForImport.R
@@ -561,6 +561,14 @@ test_that(
                      "Some records failed validation")
     
     expect_true(attr(ImportData, "invalid")$value == invalid_value)
+    
+    
+    # Preserve missing values with checkboxes
+    TheData[[test_field]][2] <- NA
+    ImportData <- 
+      expect_warning(castForImport(data = TheData[c("record_id", test_field)], 
+                                  rcon = rcon))
+    expect_true(is.na(ImportData[[test_field]][2]))
   }
 )
 


### PR DESCRIPTION
* alters `castCheckedForImport` and `castRaw` to preserve missing values when casting for import. 
* NEWS updated with the change
* Tests added to verify desired behavior