### PR TITLE
Issue 209 standardize output

### DIFF
--- a/R/deleteArms.R
+++ b/R/deleteArms.R
@@ -77,13 +77,17 @@ deleteArms.redcapApiConnection <- function(rcon,
                             config = config)
     
     if (response$status_code != 200) return(redcapError(response, error_handling))
+  } else {
+    response <- ""
   }
-  
-  message(sprintf("Arms Deleted: %s", 
-                  if (length(arms) > 0) paste0(arms, collapse = ", ") else "None."))
   
   if (refresh && rcon$has_arms()){
     rcon$refresh_arms()
+    # Changes to arms can impact events and if the project is 
+    # still considered longitudinal
+    rcon$refresh_events() 
     rcon$refresh_projectInformation()
   }
+  
+  invisible(as.character(response))
 }

--- a/R/deleteArms.R
+++ b/R/deleteArms.R
@@ -78,7 +78,7 @@ deleteArms.redcapApiConnection <- function(rcon,
     
     if (response$status_code != 200) return(redcapError(response, error_handling))
   } else {
-    response <- ""
+    response <- "0"
   }
   
   if (refresh && rcon$has_arms()){

--- a/R/deleteDags.R
+++ b/R/deleteDags.R
@@ -85,6 +85,5 @@ deleteDags.redcapApiConnection <- function(rcon,
     rcon$refresh_dags()
   }
   
-  message(sprintf("DAGs deleted: %s", 
-                  as.character(response)))
+  invisible(as.character(response))
 }

--- a/R/deleteEvents.R
+++ b/R/deleteEvents.R
@@ -70,11 +70,13 @@ deleteEvents.redcapApiConnection <- function(rcon,
   
   if (response$status_code != 200) return(redcapError(response, error_handling))
   
-  message(sprintf("Events deleted: %s", 
-                  as.character(response)))
-  
   if (refresh && rcon$has_events()){
     rcon$refresh_events()
+    # changing events can change availability of arms
+    # and whether a project is considered longitudinal
+    rcon$refresh_arms()
     rcon$refresh_projectInformation()
   }
+  
+  invisible(as.character(response))
 }

--- a/R/deleteFiles.R
+++ b/R/deleteFiles.R
@@ -132,6 +132,6 @@ deleteFiles.redcapApiConnection <- function(rcon,
   if (response$status_code != "200")
     redcapError(response, error_handling)
   else 
-    message("The file was successfully deleted")
+    invisible(TRUE)
   
 }

--- a/R/deleteFromFileRepository.R
+++ b/R/deleteFromFileRepository.R
@@ -84,8 +84,6 @@ deleteFromFileRepository.redcapApiConnection <- function(rcon,
                  error_handling = error_handling)
   }
   
-  message(sprintf("File deleted: %s", file_path))
-  
   # Refresh the cached File Repository ------------------------------
   if (refresh && rcon$has_fileRepository()){
     rcon$refresh_fileRepository()

--- a/R/deleteRecords.R
+++ b/R/deleteRecords.R
@@ -16,7 +16,7 @@
 #'   the specified arm.  
 #' 
 #' @return
-#' `deleteRecords` returns a character value giving the number of records deleted.
+#' `deleteRecords` invisibly returns a character value giving the number of records deleted.
 #' 
 #' @seealso 
 #' [exportRecords()], \cr
@@ -123,5 +123,5 @@ deleteRecords.redcapApiConnection <- function(rcon,
     return(redcapError(response, error_handling))
   } 
   
-  as.character(response)
+  invisible(as.character(response))
 }

--- a/R/deleteUserRoles.R
+++ b/R/deleteUserRoles.R
@@ -86,5 +86,5 @@ deleteUserRoles.redcapApiConnection <- function(rcon,
     rcon$refresh_user_roles()
   }
   
-  message(sprintf("User Roles Deleted: %s", as.character(response)))
+  invisible(as.character(response))
 }

--- a/R/deleteUsers.R
+++ b/R/deleteUsers.R
@@ -86,5 +86,5 @@ deleteUsers.redcapApiConnection <- function(rcon,
     rcon$refresh_users()
   }
   
-  message(sprintf("Users Deleted: %s", as.character(response)))
+  invisible(as.character(response))
 }

--- a/R/docsArmsMethods.R
+++ b/R/docsArmsMethods.R
@@ -44,11 +44,9 @@
 #' | `arm_num` | The ID number for the arm in the project. | 
 #' | `name`    | The display name of the arm.              |
 #' 
-#' `importArms` has no return and prints a message indicating the 
-#'   number of arms imported.
+#' `importArms` invisibly returns the number of arms imported.
 #'   
-#' `deleteArms` has no return and prints a message indicating the
-#'   number of arms deleted.
+#' `deleteArms` invisibly returns the number of arms deleted.
 #'   
 #' @examples
 #' \dontrun{

--- a/R/docsDagAssignmentMethods.R
+++ b/R/docsDagAssignmentMethods.R
@@ -25,8 +25,7 @@
 #' | `username` | The unique user name for each user in the project. | 
 #' | `redcap_data_access_group` | The unique Data Access Group name to which the user is assigned. |
 #' 
-#' `importUserDagAssignments` has no return and prints a message indicating the number 
-#'   of assignments imported.
+#' `importUserDagAssignments` invisibly returns the number of assignments imported.
 #'   
 #' @seealso 
 #' [exportDags()],\cr

--- a/R/docsDagMethods.R
+++ b/R/docsDagMethods.R
@@ -30,11 +30,9 @@
 #' | `unique_group_name`      | The internal unique group name.                    |
 #' | `data_access_group_id`   | The internal numeric identifier.                   |
 #' 
-#' `importDags` has no return, but will print a message indicating the
-#' number of Data Access Groups imported. 
+#' `importDags` invisibly returns the number of Data Access Groups imported. 
 #' 
-#' `deleteDags` has no return, but will print a message indicating the
-#' number of Data Access Groups deleted.
+#' `deleteDags` invisibly returns the number of Data Access Groups deleted.
 #' 
 #'
 #' @seealso

--- a/R/docsEventMethods.R
+++ b/R/docsEventMethods.R
@@ -61,11 +61,9 @@
 #'  | offset_min         | The number of days before the `days_offset` during which the event may occur. This field is only provided when the scheduling module is enabled. |
 #'  | offset_max         | The number of days before the `days_offset` during which the event may occur. This field is only provided when  the scheduling module is enabled. |
 #' 
-#' `importEvents` has no return and prints a message indicating how many
-#'   events were added or modified.
+#' `importEvents` invisibly returns the number of events added or modified.
 #'   
-#' `deleteEvents` has no return and prints a message indicating how many
-#'   events were deleted.
+#' `deleteEvents` invisibly returns the number of events deleted.
 #'   
 #' @seealso 
 #' [exportMappings()], \cr

--- a/R/docsFileMethods.R
+++ b/R/docsFileMethods.R
@@ -34,14 +34,14 @@
 #' may be appended as a prefix.
 #' 
 #' @return 
-#' `exportFiles` has no return and displays a message with file path to
-#'   which the exported file was saved.
+#' `exportFiles` insibile returns the file path to which the exported 
+#'   file was saved.
 #'   
-#' `importFiles` has no return and displays a message indicating whether
-#'   the import was successful.
+#' `importFiles` invisibly returns `TRUE` when successful, or throws an 
+#'   error if the import failed.
 #'
-#' `deleteFiles` has no return and displays a message indicating whether
-#'   the file was successfully deleted from the project.
+#' `deleteFiles` invisible returns `TRUE` when successful, or throws an
+#'   error if the deletion failed.
 #'   
 #' @examples
 #' \dontrun{

--- a/R/docsFileRepositoryMethods.R
+++ b/R/docsFileRepositoryMethods.R
@@ -35,18 +35,24 @@
 #'   Deleted files will remain in the recycling bin for up to 30 days. 
 #'   
 #' @return 
-#' `exportFileRepository` and `importFileRepository` display messages 
-#' giving the directory to which files were saved to the local machine and 
-#' File Repository, respectively. They also return a data frame with the columns: 
+#' `exportFileRepository` returns a data frame with the locations to which 
+#' the files were saved on the local system. It has the columns: 
 #' 
 #' |             |                                           |
 #' |-------------|-------------------------------------------|
 #' | `directory` | The directory in which the file is saved. | 
 #' | `filename`  |  The name of the saved file.              |
 #' 
-#' `deleteFileRepository` displays a message giving the files that were 
-#' deleted from the File Repository. It also returns a data frame with the 
-#' columns:
+#' `importFileRepository` returns a data frame with the locations to which 
+#' the files were saved on the local system. It has the columns: 
+#' 
+#' |             |                                           |
+#' |-------------|-------------------------------------------|
+#' | `directory` | The directory in which the file is saved. | 
+#' | `filename`  |  The name of the saved file.              |
+#' 
+#' `deleteFileRepository` returns a data frame listing the files that 
+#'   were deleted from the file repository. It has the columns:
 #' 
 #' |                |                                                                           |
 #' |----------------|---------------------------------------------------------------------------|

--- a/R/docsFromFileRepository.R
+++ b/R/docsFromFileRepository.R
@@ -33,15 +33,6 @@
 #' | `directory` | The directory in which the file is saved. | 
 #' | `filename`  | The name of the saved file.               |
 #'
-#' 
-#' Additionally, `exportFromFileRepository` displays a message 
-#'   with the file path to which the file was saved on the local computer. 
-#' 
-#' `importToFileRepository` displays a message with the path in the
-#'   file repository to which the file is imported. 
-#'   
-#' `deleteFromFileRepository` displays a message with the path on the
-#'   file repostiory from which the file was deleted.
 #'   
 #' @seealso
 #' [exportFileRepository()], \cr

--- a/R/docsMappingMethods.R
+++ b/R/docsMappingMethods.R
@@ -29,6 +29,7 @@
 #' | `unique_event_name` | The unique event name to which the instrument is assigned.    | 
 #' | `form`              | The REDCap assigned instrument name mapped to the event.      |
 #' 
+#' `importMappings` invisible returns the number of mappings added or edited.
 #' 
 #' @seealso 
 #' [exportFieldNames()],\cr

--- a/R/docsMetaDataMethods.R
+++ b/R/docsMetaDataMethods.R
@@ -76,8 +76,7 @@
 #' | `field_annotation`               | Contains annotations such as units of measures. Also contains action tags. |
 #'
 #' 
-#' `importMetaData` has no return and displays a message indicating 
-#'   the number of fields that were imported.
+#' `importMetaData` invisibly returns the number of fields that were imported.
 #' 
 #' @seealso 
 #' [exportFieldNames()],\cr

--- a/R/docsProjectInformationMethods.R
+++ b/R/docsProjectInformationMethods.R
@@ -78,8 +78,7 @@
 #' | `bypass_branching_erase_field_prompt` | Boolean value indicating if the box for "Prevent branching logic from hiding fields that have values" has been checked under "Additional Customizations."
 #'
 #' 
-#' `importProjectInformation` has no return and displays a message 
-#'   indicating the number of fields updated.
+#' `importProjectInformation` invisibly returns the number of fields updated.
 #' 
 #' @examples
 #' \dontrun{

--- a/R/docsRecordsManagementMethods.R
+++ b/R/docsRecordsManagementMethods.R
@@ -22,8 +22,8 @@
 #'   determined by looking up the highest record ID number in the 
 #'   project and incrementing it by 1. 
 #'
-#' `renameRecord` return a logical value that indicates if the 
-#'   operation was successful.
+#' `renameRecord` invisibly returns a logical value that indicates if the 
+#'   operation was successful. Otherwise, an error is thrown.
 #'   
 #'   
 #'   

--- a/R/docsRepeatingInstrumentEventMethods.R
+++ b/R/docsRepeatingInstrumentEventMethods.R
@@ -35,8 +35,7 @@
 #' | `form_name`         | The form name, as given in the second column of the Meta Data | 
 #' | `custom_form_label` | A custom display string for the repeating instrument/event    |
 #' 
-#' `importRepeatingInstrumentsEvents` has no return and displays a message
-#' describing the number of rows imported.
+#' `importRepeatingInstrumentsEvents` invisibly returns the number of rows imported.
 #' 
 #' @examples
 #' \dontrun{

--- a/R/docsUserMethods.R
+++ b/R/docsUserMethods.R
@@ -131,11 +131,9 @@
 #' and the form export rights columns have the naming pattern
 #' `[form_name]_export_access`.
 #' 
-#' `importUsers` has no return value and displays a message indicating how
-#' many users were added or modified.
+#' `importUsers` invisibly returns the number of users that were added or modified.
 #' 
-#' `deleteUsers` has no return value and displays a message indicating how 
-#' many users were deleted. 
+#' `deleteUsers` invisibly returns the number of users that were deleted. 
 #' 
 #' @examples
 #' \dontrun{

--- a/R/docsUserRoleAssignmentMethods.R
+++ b/R/docsUserRoleAssignmentMethods.R
@@ -23,6 +23,9 @@
 #' | `unique_role_name`   | The unique role name to which the user is assigned.  |
 #' | `data_access_group`  | The Data Access Group to which the user is assigned. |
 #' 
+#' `importUserRoleAssignments` invisibly returns the number of user roles 
+#'   assignments added or modified.
+#' 
 #' @examples
 #' \dontrun{
 #' unlockREDCap(connections = c(rcon = "project_alias"), 

--- a/R/docsUserRoleMethods.R
+++ b/R/docsUserRoleMethods.R
@@ -60,11 +60,10 @@
 #' and the form export rights columns have the naming pattern
 #' `[form_name]_export_access`.
 #' 
-#' `importUserRoles` has no return value and displays a message indicating how
-#' many users were added or modified.
+#' `importUserRoles` invisibly returns the number of user roles that were 
+#'   added or modified.
 #' 
-#' `deleteUserRoles` has no return value and displays a message indicating how 
-#' many users were deleted.
+#' `deleteUserRoles` invisibly returns the number of user roles that were deleted.
 #' 
 #' @examples
 #' \dontrun{

--- a/R/exportFileRepository.R
+++ b/R/exportFileRepository.R
@@ -121,9 +121,6 @@ exportFileRepository.redcapApiConnection <- function(rcon,
     } # end if/else
   } # end for
   
-  message(sprintf("%s folders have been created", 
-                  n_folder_created))
-  
   do.call("rbind", ExportedFiles)
 } 
 

--- a/R/exportFiles.R
+++ b/R/exportFiles.R
@@ -156,7 +156,6 @@ exportFiles.redcapApiConnection <- function(rcon,
                                            dir_create = FALSE, 
                                            file_prefix = prefix)
   
-  message(sprintf("The file was saved to '%s'", 
-                  file.path(file_saved$directory, 
-                            file_saved$filename)))
+  invisible(file.path(file_saved$directory, 
+                      file_saved$filename))
 }

--- a/R/exportFromFileRepository.R
+++ b/R/exportFromFileRepository.R
@@ -90,9 +90,5 @@ exportFromFileRepository.redcapApiConnection <- function(rcon,
                                              dir = dir, 
                                              dir_create = dir_create)
   
-  message(sprintf("File Saved: %s", 
-                  file.path(ExportedFile$directory, 
-                            ExportedFile$filename)))
-  
   ExportedFile
 }

--- a/R/exportPDF.R
+++ b/R/exportPDF.R
@@ -34,9 +34,8 @@
 #'
 #'
 #' @return 
-#' `exportPdf` has no return. After saving the file to the local 
-#' computer, a message is displayed providing the location of the file
-#' on the system.
+#' `exportPdf` invisibly returns the location on the local system 
+#'   to whihc the files is saved.
 #'
 #' @seealso
 #' [exportMetaData()],\cr
@@ -185,6 +184,6 @@ exportPdf.redcapApiConnection <- function(rcon,
                              file_prefix = "", 
                              filename = filename)
   
-  message("The file was saved to '", file.path(dir, filename), "'")
+  invisible(file.path(dir, filename))
 }
   

--- a/R/importArms.R
+++ b/R/importArms.R
@@ -94,11 +94,13 @@ importArms.redcapApiConnection <- function(rcon,
   
   if (response$status_code != 200) return(redcapError(response, error_handling))
   
-  message(sprintf("Arms imported: %s", 
-                  as.character(response)))
-  
   if (refresh && rcon$has_arms()){
     rcon$refresh_arms()
+    # Changes to arms can impact events and if the project is 
+    # still considered longitudinal
+    rcon$refresh_events()
     rcon$refresh_projectInformation()
   }
+  
+  invisible(as.character(response))
 }

--- a/R/importDags.R
+++ b/R/importDags.R
@@ -95,6 +95,5 @@ importDags.redcapApiConnection <- function(rcon,
     rcon$refresh_dags()
   }
   
-  message(sprintf("DAGs imported: %s", 
-                  as.character(response)))
+  invisible(as.character(response))
 }

--- a/R/importEvents.R
+++ b/R/importEvents.R
@@ -88,11 +88,13 @@ importEvents.redcapApiConnection <- function(rcon,
   
   if (response$status_code != 200) return(redcapError(response, error_handling))
   
-  message(sprintf("Events imported: %s", 
-                  as.character(response)))
-  
   if (refresh && rcon$has_events()){
     rcon$refresh_events()
+    # changing events can change availability of arms
+    # and whether a project is considered longitudinal
+    rcon$refresh_arms()
     rcon$refresh_projectInformation()
   }
+  
+  invisible(as.character(response))
 }

--- a/R/importFiles.R
+++ b/R/importFiles.R
@@ -32,7 +32,7 @@ importFiles.redcapApiConnection <- function(rcon,
   if (is.numeric(record)) record <- as.character(record)
   
    ##################################################################
-  # Argumetn Validation
+  # Argument Validation
   
   coll <- checkmate::makeAssertCollection()
   
@@ -162,5 +162,5 @@ importFiles.redcapApiConnection <- function(rcon,
   if (response$status_code != "200") 
     redcapError(response, error_handling)
   else 
-    message("The file was successfully uploaded")
+    invisible(TRUE)
 }

--- a/R/importMappings.R
+++ b/R/importMappings.R
@@ -94,9 +94,9 @@ importMappings.redcapApiConnection <- function(rcon,
     redcapError(response, error_handling)
   } 
   
-  message("Mappings imported: ", as.character(response))
-  
   if (refresh && rcon$has_mapping()){
     rcon$refresh_mapping()
   }
+  
+  invisible(as.character(response))
 }

--- a/R/importMetaData.R
+++ b/R/importMetaData.R
@@ -135,8 +135,6 @@ importMetaData.redcapApiConnection <- function(rcon,
   
   response <- as.character(response)
   
-  message(sprintf("Fields Imported: %s", response))
-  
   if (refresh){
     if (rcon$has_metadata()){
       rcon$refresh_metadata()
@@ -146,6 +144,8 @@ importMetaData.redcapApiConnection <- function(rcon,
       rcon$refresh_instruments()
     }
   }
+  
+  invisible(as.character(response))
 }
 
 #####################################################################

--- a/R/importProjectInformation.R
+++ b/R/importProjectInformation.R
@@ -83,12 +83,11 @@ importProjectInformation.redcapApiConnection <- function(rcon,
   
   if (response$status_code != 200) return(redcapError(response, error_handling))
   
-  message(sprintf("Fields updated: %s", 
-                  as.character(response)))
-  
   if (refresh && rcon$has_projectInformation()){
     rcon$refresh_projectInformation()
   }
+  
+  invisible(as.character(response))
 }
 
 #####################################################################

--- a/R/importRepeatingInstrumentsEvents.R
+++ b/R/importRepeatingInstrumentsEvents.R
@@ -76,11 +76,10 @@ importRepeatingInstrumentsEvents.redcapApiConnection <- function(rcon,
   
   if (response$status_code != 200) return(redcapError(response, error_handling))
   
-  message(sprintf("Rows imported: %s", 
-                  as.character(response)))
-  
   if (refresh && rcon$has_repeatInstrumentEvent()){
     rcon$refresh_projectInformation()
     rcon$refresh_repeatInstrumentEvent()
   }
+  
+  invisible(as.character(response))
 }

--- a/R/importToFileRepository.R
+++ b/R/importToFileRepository.R
@@ -88,7 +88,6 @@ importToFileRepository.redcapApiConnection <- function(rcon,
   
   file_path <- file.path(fileRepositoryPath(folder_id = folder_id, 
                                             fileRepo = fileRepo))
-  message(sprintf("File saved to: %s", file_path))
   
   data.frame(directory = dirname(file_path), 
              filename = basename(file), 

--- a/R/importUserDagAssignments.R
+++ b/R/importUserDagAssignments.R
@@ -104,6 +104,5 @@ importUserDagAssignments.redcapApiConnection <- function(rcon,
                  error_handling = error_handling)
   }
   
-  message(sprintf("User-DAG Assignments Added/Modified: %s", 
-                  as.character(response)))
+  invisible(as.character(response))
 }

--- a/R/importUserRoleAssignments.R
+++ b/R/importUserRoleAssignments.R
@@ -112,6 +112,5 @@ importUserRoleAssignments.redcapApiConnection <- function(rcon,
     rcon$refresh_users()
   }
   
-  message(sprintf("User-Role Assignments Added/Updated: %s", 
-                  as.character(response)))
+  invisible(as.character(response))
 }

--- a/R/importUserRoles.R
+++ b/R/importUserRoles.R
@@ -97,5 +97,5 @@ importUserRoles.redcapApiConnection <- function(rcon,
     rcon$refresh_user_roles()
   }
   
-  message(sprintf("User Roles Added/Modified: %s", as.character(response)))
+  invisible(as.character(response))
 }

--- a/R/importUsers.R
+++ b/R/importUsers.R
@@ -115,7 +115,7 @@ importUsers.redcapApiConnection <- function(rcon,
     rcon$refresh_users()
   }
   
-  message(sprintf("Users Added/Modified: %s", as.character(response)))
+  invisible(as.character(response))
 }
 
 

--- a/R/renameRecord.R
+++ b/R/renameRecord.R
@@ -88,5 +88,5 @@ renameRecord.redcapApiConnection <- function(rcon,
                 error_handling = error_handling)
   }
   
-  as.character(response) == "1"
+  invisible(as.character(response) == "1")
 }

--- a/R/switchDag.R
+++ b/R/switchDag.R
@@ -14,7 +14,8 @@
 #' @param refresh `logical(1)` If `TRUE`, the cached data access
 #'   group assignments will be refreshed.
 #'   
-#' @return Returns `TRUE` when the call is completed successfully.
+#' @return Invisibly returns `TRUE` when the call is completed successfully.
+#'   Otherwise an error is thrown.
 #' 
 #' @seealso 
 #' [exportDags()],\cr
@@ -136,5 +137,5 @@ switchDag.redcapApiConnection <- function(rcon,
     message(as.character(response))
   }
   
-  success
+  invisible(success)
 }

--- a/man/armsMethods.Rd
+++ b/man/armsMethods.Rd
@@ -87,11 +87,9 @@ that may not otherwise be supported by \code{redcapAPI}.}
 }
 
 
-\code{importArms} has no return and prints a message indicating the
-number of arms imported.
+\code{importArms} invisibly returns the number of arms imported.
 
-\code{deleteArms} has no return and prints a message indicating the
-number of arms deleted.
+\code{deleteArms} invisibly returns the number of arms deleted.
 }
 \description{
 These methods enable the user to export the current arms

--- a/man/dagAssignmentMethods.Rd
+++ b/man/dagAssignmentMethods.Rd
@@ -59,8 +59,7 @@ that may not otherwise be supported by \code{redcapAPI}.}
 }
 
 
-\code{importUserDagAssignments} has no return and prints a message indicating the number
-of assignments imported.
+\code{importUserDagAssignments} invisibly returns the number of assignments imported.
 }
 \description{
 These methods enable the user to export existing assignments

--- a/man/dagMethods.Rd
+++ b/man/dagMethods.Rd
@@ -79,11 +79,9 @@ that may not otherwise be supported by \code{redcapAPI}.}
 }
 
 
-\code{importDags} has no return, but will print a message indicating the
-number of Data Access Groups imported.
+\code{importDags} invisibly returns the number of Data Access Groups imported.
 
-\code{deleteDags} has no return, but will print a message indicating the
-number of Data Access Groups deleted.
+\code{deleteDags} invisibly returns the number of Data Access Groups deleted.
 }
 \description{
 These methods enable the user to export existing Data Access Groups,

--- a/man/deleteRecords.Rd
+++ b/man/deleteRecords.Rd
@@ -45,7 +45,7 @@ body of the API call. This provides users to execute calls with options
 that may not otherwise be supported by \code{redcapAPI}.}
 }
 \value{
-\code{deleteRecords} returns a character value giving the number of records deleted.
+\code{deleteRecords} invisibly returns a character value giving the number of records deleted.
 }
 \description{
 These methods enable the user to delete records from a project.

--- a/man/eventsMethods.Rd
+++ b/man/eventsMethods.Rd
@@ -96,11 +96,9 @@ that may not otherwise be supported by \code{redcapAPI}.}
 }
 
 
-\code{importEvents} has no return and prints a message indicating how many
-events were added or modified.
+\code{importEvents} invisibly returns the number of events added or modified.
 
-\code{deleteEvents} has no return and prints a message indicating how many
-events were deleted.
+\code{deleteEvents} invisibly returns the number of events deleted.
 }
 \description{
 These methods enable the user to export event settings,

--- a/man/exportPdf.Rd
+++ b/man/exportPdf.Rd
@@ -66,9 +66,8 @@ body of the API call. This provides users to execute calls with options
 that may not otherwise be supported by \code{redcapAPI}.}
 }
 \value{
-\code{exportPdf} has no return. After saving the file to the local
-computer, a message is displayed providing the location of the file
-on the system.
+\code{exportPdf} invisibly returns the location on the local system
+to whihc the files is saved.
 }
 \description{
 These methods allow the user to download PDF files of

--- a/man/fileMethods.Rd
+++ b/man/fileMethods.Rd
@@ -111,14 +111,14 @@ body of the API call. This provides users to execute calls with options
 that may not otherwise be supported by \code{redcapAPI}.}
 }
 \value{
-\code{exportFiles} has no return and displays a message with file path to
-which the exported file was saved.
+\code{exportFiles} insibile returns the file path to which the exported
+file was saved.
 
-\code{importFiles} has no return and displays a message indicating whether
-the import was successful.
+\code{importFiles} invisibly returns \code{TRUE} when successful, or throws an
+error if the import failed.
 
-\code{deleteFiles} has no return and displays a message indicating whether
-the file was successfully deleted from the project.
+\code{deleteFiles} invisible returns \code{TRUE} when successful, or throws an
+error if the deletion failed.
 }
 \description{
 These methods enable to the user to export a file stored

--- a/man/fileRepositoryMethods.Rd
+++ b/man/fileRepositoryMethods.Rd
@@ -108,18 +108,24 @@ body of the API call. This provides users to execute calls with options
 that may not otherwise be supported by \code{redcapAPI}.}
 }
 \value{
-\code{exportFileRepository} and \code{importFileRepository} display messages
-giving the directory to which files were saved to the local machine and
-File Repository, respectively. They also return a data frame with the columns:\tabular{ll}{
+\code{exportFileRepository} returns a data frame with the locations to which
+the files were saved on the local system. It has the columns:\tabular{ll}{
     \tab  \cr
    \code{directory} \tab The directory in which the file is saved. \cr
    \code{filename} \tab The name of the saved file. \cr
 }
 
 
-\code{deleteFileRepository} displays a message giving the files that were
-deleted from the File Repository. It also returns a data frame with the
-columns:\tabular{ll}{
+\code{importFileRepository} returns a data frame with the locations to which
+the files were saved on the local system. It has the columns:\tabular{ll}{
+    \tab  \cr
+   \code{directory} \tab The directory in which the file is saved. \cr
+   \code{filename} \tab The name of the saved file. \cr
+}
+
+
+\code{deleteFileRepository} returns a data frame listing the files that
+were deleted from the file repository. It has the columns:\tabular{ll}{
     \tab  \cr
    \code{folder_id} \tab The REDCap assigned ID number for the folder. This will be \code{NA} for files. \cr
    \code{doc_id} \tab The REDCap assigned ID number for the file. \cr

--- a/man/fromFileRepositoryMethods.Rd
+++ b/man/fromFileRepositoryMethods.Rd
@@ -94,16 +94,6 @@ with the columns:\tabular{ll}{
    \code{directory} \tab The directory in which the file is saved. \cr
    \code{filename} \tab The name of the saved file. \cr
 }
-
-
-Additionally, \code{exportFromFileRepository} displays a message
-with the file path to which the file was saved on the local computer.
-
-\code{importToFileRepository} displays a message with the path in the
-file repository to which the file is imported.
-
-\code{deleteFromFileRepository} displays a message with the path on the
-file repostiory from which the file was deleted.
 }
 \description{
 These methods enable the user to export, import, or delete

--- a/man/mappingMethods.Rd
+++ b/man/mappingMethods.Rd
@@ -65,6 +65,9 @@ that may not otherwise be supported by \code{redcapAPI}.}
    \code{unique_event_name} \tab The unique event name to which the instrument is assigned. \cr
    \code{form} \tab The REDCap assigned instrument name mapped to the event. \cr
 }
+
+
+\code{importMappings} invisible returns the number of mappings added or edited.
 }
 \description{
 These methods enable the user to export and add/modify the

--- a/man/metaDataMethods.Rd
+++ b/man/metaDataMethods.Rd
@@ -92,8 +92,7 @@ documented here, but the most commonly used within \code{redcapAPI} are
 }
 
 
-\code{importMetaData} has no return and displays a message indicating
-the number of fields that were imported.
+\code{importMetaData} invisibly returns the number of fields that were imported.
 }
 \description{
 These methods provide the user access to a REDCap project's

--- a/man/projectInformationMethods.Rd
+++ b/man/projectInformationMethods.Rd
@@ -86,8 +86,7 @@ that may not otherwise be supported by \code{redcapAPI}.}
 }
 
 
-\code{importProjectInformation} has no return and displays a message
-indicating the number of fields updated.
+\code{importProjectInformation} invisibly returns the number of fields updated.
 }
 \description{
 These methods enable the user to export or update project

--- a/man/recordsManagementMethods.Rd
+++ b/man/recordsManagementMethods.Rd
@@ -66,8 +66,8 @@ that may not otherwise be supported by \code{redcapAPI}.}
 determined by looking up the highest record ID number in the
 project and incrementing it by 1.
 
-\code{renameRecord} return a logical value that indicates if the
-operation was successful.
+\code{renameRecord} invisibly returns a logical value that indicates if the
+operation was successful. Otherwise, an error is thrown.
 }
 \description{
 These methods enable the user to get the next record name

--- a/man/repeatingInstrumentMethods.Rd
+++ b/man/repeatingInstrumentMethods.Rd
@@ -66,8 +66,7 @@ that may not otherwise be supported by \code{redcapAPI}.}
 }
 
 
-\code{importRepeatingInstrumentsEvents} has no return and displays a message
-describing the number of rows imported.
+\code{importRepeatingInstrumentsEvents} invisibly returns the number of rows imported.
 }
 \description{
 These methods enable the user to export the existing

--- a/man/switchDag.Rd
+++ b/man/switchDag.Rd
@@ -42,7 +42,8 @@ body of the API call. This provides users to execute calls with options
 that may not otherwise be supported by \code{redcapAPI}.}
 }
 \value{
-Returns \code{TRUE} when the call is completed successfully.
+Invisibly returns \code{TRUE} when the call is completed successfully.
+Otherwise an error is thrown.
 }
 \description{
 This method enables the current API user to switch

--- a/man/userMethods.Rd
+++ b/man/userMethods.Rd
@@ -137,11 +137,9 @@ Form access rights columns have the naming pattern \verb{[form_name]_access}
 and the form export rights columns have the naming pattern
 \verb{[form_name]_export_access}.
 
-\code{importUsers} has no return value and displays a message indicating how
-many users were added or modified.
+\code{importUsers} invisibly returns the number of users that were added or modified.
 
-\code{deleteUsers} has no return value and displays a message indicating how
-many users were deleted.
+\code{deleteUsers} invisibly returns the number of users that were deleted.
 }
 \description{
 These methods enable the user to add and remove users from

--- a/man/userRoleAssignmentMethods.Rd
+++ b/man/userRoleAssignmentMethods.Rd
@@ -63,6 +63,10 @@ that may not otherwise be supported by \code{redcapAPI}.}
    \code{unique_role_name} \tab The unique role name to which the user is assigned. \cr
    \code{data_access_group} \tab The Data Access Group to which the user is assigned. \cr
 }
+
+
+\code{importUserRoleAssignments} invisibly returns the number of user roles
+assignments added or modified.
 }
 \description{
 These methods enable the user to export the user-role

--- a/man/userRoleMethods.Rd
+++ b/man/userRoleMethods.Rd
@@ -129,11 +129,10 @@ Form access rights columns have the naming pattern \verb{[form_name]_access}
 and the form export rights columns have the naming pattern
 \verb{[form_name]_export_access}.
 
-\code{importUserRoles} has no return value and displays a message indicating how
-many users were added or modified.
+\code{importUserRoles} invisibly returns the number of user roles that were
+added or modified.
 
-\code{deleteUserRoles} has no return value and displays a message indicating how
-many users were deleted.
+\code{deleteUserRoles} invisibly returns the number of user roles that were deleted.
 }
 \description{
 These methods enable the user to export user roles,

--- a/tests/testthat/test-100-projectInfo-functionality.R
+++ b/tests/testthat/test-100-projectInfo-functionality.R
@@ -29,15 +29,19 @@ test_that(
     NewInfo <- data.frame(project_pi_lastname = "Not Garbett", 
                           display_today_now_button = 0)
     
-    expect_message(importProjectInformation(rcon, 
-                                            NewInfo), 
-                   "Fields updated: 2")
+    n_imported <- importProjectInformation(rcon, 
+                                            NewInfo)
+    expect_equal(n_imported, "2")
     
+    n_imported <- importProjectInformation(rcon, 
+                                           NewInfo)
+    expect_equal(n_imported, "2")
     
     # cleanup 
-    expect_message(importProjectInformation(rcon, 
-                                            CurrentInfo), 
-                   "Fields updated: 18")
+    
+    n_imported <- importProjectInformation(rcon, 
+                                           CurrentInfo)
+    expect_equal(n_imported, "18")
   }
 )
 

--- a/tests/testthat/test-101-userMethods-Functionality.R
+++ b/tests/testthat/test-101-userMethods-Functionality.R
@@ -12,19 +12,18 @@ test_that(
     }
     
     # Import a user
-    expect_message(importUsers(rcon, 
-                               data = data.frame(username = EXPENDABLE_USER)), 
-                   "Users Added/Modified: 1")
-    
+    n_imported <- importUsers(rcon, 
+                              data = data.frame(username = EXPENDABLE_USER))
+    expect_equal(n_imported, "1")
     # Verify the user was added
     expect_true(EXPENDABLE_USER %in% rcon$users()$username)
     
     # Modify the user permissions
     
-    expect_message(importUsers(rcon, 
-                               data = data.frame(username = EXPENDABLE_USER, 
-                                                 alerts = 1)), 
-                   "Users Added/Modified: 1")
+    n_imported <- importUsers(rcon, 
+                              data = data.frame(username = EXPENDABLE_USER, 
+                                                alerts = 1)) 
+    expect_equal(n_imported, "1")
     
     Users <- exportUsers(rcon)
     Users <- Users[rcon$users()$username %in% EXPENDABLE_USER, ]
@@ -166,8 +165,8 @@ test_that(
             "User tests without an expendable user could have negative consequences and are not run.")
 
     # Clean Up
-    expect_message(deleteUsers(rcon, 
-                               users = EXPENDABLE_USER), 
-                   "Users Deleted: 1")
+    n_deleted <- deleteUsers(rcon, 
+                               users = EXPENDABLE_USER) 
+    expect_equal(n_deleted, "1")
   }
 )

--- a/tests/testthat/test-102-userRoleMethods-Functionality.R
+++ b/tests/testthat/test-102-userRoleMethods-Functionality.R
@@ -10,9 +10,9 @@ test_that(
                           user_rights = 1)
   
     
-    expect_message(importUserRoles(rcon, 
-                                   data = NewRole), 
-                   "User Roles Added/Modified: 1")
+    n_imported <- importUserRoles(rcon, 
+                                  data = NewRole)
+    expect_equal(n_imported, "1")
     
     # Verify that the user role was updated. 
     UserRoles <- exportUserRoles(rcon)
@@ -38,9 +38,9 @@ test_that(
                              design = 1, 
                              reports = 1)
     
-    expect_message(importUserRoles(rcon, 
-                                   data = UpdateRole), 
-                   "User Roles Added/Modified: 1")
+    n_imported <- importUserRoles(rcon, 
+                                  data = UpdateRole)
+    expect_equal(n_imported, "1")
     
     UserRoles <- exportUserRoles(rcon)
     
@@ -53,7 +53,8 @@ test_that(
     rcon$user_roles()
     nroles <- nrow(rcon$user_roles())
     # Cleanup by deleting the user role
-    expect_message(deleteUserRoles(rcon, UserRoles$unique_role_name[1]), 
-                   sprintf("User Roles Deleted: %s", nroles))
+    n_deleted <- deleteUserRoles(rcon, 
+                                 UserRoles$unique_role_name[1])
+    expect_equal(n_deleted, "1")
   }
 )

--- a/tests/testthat/test-103-userRoleAssignmentMethods-Functionality.R
+++ b/tests/testthat/test-103-userRoleAssignmentMethods-Functionality.R
@@ -33,9 +33,9 @@ test_that(
                  unique_role_name = the_role,
                  stringsAsFactors = FALSE)
 
-    expect_message(importUserRoleAssignments(rcon,
-                                             data = ImportAssignmentTest),
-                   "User-Role Assignments Added/Updated: 1")
+    n_imported <- importUserRoleAssignments(rcon,
+                                            data = ImportAssignmentTest)
+    expect_equal(n_imported, "1")
 
     CompareFrame <- rcon$user_role_assignment()
     CompareFrame <- CompareFrame[CompareFrame$username == the_user, ]
@@ -48,17 +48,17 @@ test_that(
                  unique_role_name = NA_character_,
                  stringsAsFactors = FALSE)
     
-    expect_message(importUserRoleAssignments(rcon, 
-                                             data = ImportAssignmentTest),
-                   "User-Role Assignments Added/Updated: 1")
+    n_imported <- importUserRoleAssignments(rcon, 
+                                             data = ImportAssignmentTest)
+    expect_equal(n_imported, "1")
     
     CompareFrame <- rcon$user_role_assignment()
     CompareFrame <- CompareFrame[CompareFrame$username == the_user, ]
     
     expect_true(is.na(CompareFrame$unique_role_name))
 
-    expect_message(deleteUserRoles(rcon, the_role), 
-                   "User Roles Deleted: 1")
+    n_deleted <- deleteUserRoles(rcon, the_role)
+    expect_equal(n_deleted, "1")
   }
 )
 

--- a/tests/testthat/test-104-dagMethods-Functionality.R
+++ b/tests/testthat/test-104-dagMethods-Functionality.R
@@ -33,6 +33,6 @@ test_that(
     n_deleted <- deleteDags(rcon, 
                             deleted_groups)
     expect_equal(n_deleted, 
-                 as.character(length(delted_groups))) 
+                 as.character(length(deleted_groups))) 
   }
 )

--- a/tests/testthat/test-104-dagMethods-Functionality.R
+++ b/tests/testthat/test-104-dagMethods-Functionality.R
@@ -6,9 +6,9 @@ test_that(
     NewDag <- data.frame(data_access_group_name = c("Testing DAG 1", "Testing DAG 2"),
                          unique_group_name = rep(NA_character_, 2))
     
-    expect_message(importDags(rcon, 
-                              data = NewDag), 
-                   "DAGs imported: 2")
+    n_imported <- importDags(rcon, 
+                             data = NewDag)
+    expect_equal(n_imported, "2")
     
     StoredDag <- exportDags(rcon)
     
@@ -22,15 +22,17 @@ test_that(
     ChangeDag <- StoredDag[1, ]
     ChangeDag$data_access_group_name <- "A different name"
     
-    expect_message(importDags(rcon, 
-                              data = ChangeDag), 
-                   "DAGs imported: 1")
+    n_imported <- importDags(rcon, 
+                             data = ChangeDag)
+    expect_equal(n_imported, "1")
     
     expect_true("A different name" %in% rcon$dags()$data_access_group_name)
     expect_true("a_different_name" %in% rcon$dags()$unique_group_name)
     
-    expect_message(deleteDags(rcon, 
-                              rcon$dags()$unique_group_name), 
-                   "DAGs deleted")
+    deleted_groups <- rcon$dags()$unique_group_name
+    n_deleted <- deleteDags(rcon, 
+                            deleted_groups)
+    expect_equal(n_deleted, 
+                 as.character(length(delted_groups))) 
   }
 )

--- a/tests/testthat/test-105-dagAssignment-Functionality.R
+++ b/tests/testthat/test-105-dagAssignment-Functionality.R
@@ -24,9 +24,9 @@ test_that(
                                redcap_data_access_group = rcon$dags()$unique_group_name, 
                                stringsAsFactors = FALSE)
     
-    expect_message(importUserDagAssignments(rcon, 
-                                            data = AddDagAssign), 
-                   "User-DAG Assignments Added/Modified: 1")
+    n_imported <- importUserDagAssignments(rcon, 
+                                           data = AddDagAssign)
+    expect_equal(n_imported, "1")
     
     # Get the assignments and check the values
     CurrentDag <- exportUserDagAssignments(rcon)
@@ -46,9 +46,9 @@ test_that(
                               redcap_data_access_group = NA_character_, 
                               stringsAsFactors = FALSE)
     
-    expect_message(importUserDagAssignments(rcon, 
-                                            data = UnassignDag), 
-                   "User-DAG Assignments Added/Modified: 1")
+    n_imported <- importUserDagAssignments(rcon, 
+                                           data = UnassignDag)
+    expect_equal(n_imported, "1")
     
     deleteDags(rcon, 
                dags = rcon$dags()$unique_group_name)

--- a/tests/testthat/test-106-armsMethods-Functionality.R
+++ b/tests/testthat/test-106-armsMethods-Functionality.R
@@ -35,9 +35,9 @@ test_that(
   "deleteArms returns a message indicating no arms deleted.", 
   {
     local_reproducible_output(width = 200)
-    expect_message(deleteArms(rcon, 
-                              arms = rcon$arms()$arm_num), 
-                   "Arms Deleted: None")
+    n_deleted <- deleteArms(rcon, 
+                            arms = rcon$arms()$arm_num) 
+    expect_equal(n_deleted, "0")
     rcon$flush_arms()
   }
 )
@@ -57,15 +57,15 @@ test_that(
   "Import arms into a empty project.", 
   {
     # Import the arms
-    expect_message(importArms(rcon, 
-                              data = Arms), 
-                   "Arms imported: 3")
+    n_imported <- importArms(rcon, 
+                             data = Arms)
+    expect_equal(n_imported, "3")
     
     # backward compatibility with data
 
-    expect_message(importArms(rcon, 
-                              arms_data = Arms), 
-                   "Arms imported: 3")
+    n_imported <- importArms(rcon, 
+                             arms_data = Arms)
+    expect_equal(n_imported, "3")
     
     rcon$refresh_projectInformation()
     expect_equal(rcon$projectInformation()$is_longitudinal, 
@@ -76,9 +76,9 @@ test_that(
                  REDCAP_ARMS_STRUCTURE)
     
     # Now let's import the events. This should make the project longitudinal
-    expect_message(importEvents(rcon, 
-                                data = Events), 
-                   "Events imported: 3")
+    n_imported <- importEvents(rcon, 
+                               data = Events)
+    expect_equal(n_imported, "3")
     
     rcon$refresh_projectInformation()
     
@@ -96,9 +96,9 @@ test_that(
     # Now let's enable the longitudinal study and make sure we can 
     # get the arms and events out.
     
-    expect_message(importProjectInformation(rcon, 
-                                            data.frame(is_longitudinal = 1)), 
-                   "Fields updated: 1")
+    n_imported <- importProjectInformation(rcon, 
+                                           data.frame(is_longitudinal = 1))
+    expect_equal(n_imported, "1")
     
     expect_equal(exportArms(rcon), 
                  Arms)
@@ -137,13 +137,13 @@ test_that(
     }
     
     # To be considered 'longitudinal', both arms and events must be defined.
-    expect_message(importArms(rcon, 
-                              data = Arms), 
-                   "Arms imported: 3")
+    n_imported <- importArms(rcon, 
+                             data = Arms)
+    expect_equal(n_imported, "3")
     
-    expect_message(importEvents(rcon, 
-                                data = Events), 
-                   "Events imported: 3")
+    n_imported <- importEvents(rcon, 
+                               data = Events)
+    expect_equal(n_imported, "3")
     
     rcon$refresh_projectInformation()
     
@@ -158,9 +158,9 @@ test_that(
     rcon$refresh_arms()
     
     # delete the Arms
-    expect_message(deleteArms(rcon, 
-                              arms = 1:3), 
-                   "Arms Deleted: 1, 2, 3")
+    n_deleted <- deleteArms(rcon, 
+                            arms = 1:3)
+    expect_equal(n_deleted, "3")
     
     rcon$refresh_projectInformation()
     
@@ -183,13 +183,13 @@ test_that(
                  0)
     
     # To be considered 'longitudinal', both arms and events must be defined.
-    expect_message(importArms(rcon, 
-                              data = Arms), 
-                   "Arms imported: 3")
+    n_imported <- importArms(rcon, 
+                             data = Arms)
+    expect_equal(n_imported, "3")
     
-    expect_message(importEvents(rcon, 
-                                data = Events), 
-                   "Events imported: 3")
+    n_imported <- importEvents(rcon, 
+                               data = Events)
+    expect_equal(n_imported, "3")
     
     rcon$refresh_projectInformation()
     
@@ -197,14 +197,14 @@ test_that(
                  Arms)
     
     # we will need to upload events for the new arms too
-    expect_message(importArms(rcon, 
-                              data = Arms2, 
-                              override = TRUE), 
-                   "Arms imported: 2")
+    n_imported <- importArms(rcon, 
+                             data = Arms2, 
+                             override = TRUE)
+    expect_equal(n_imported, "2")
     
-    expect_message(importEvents(rcon, 
-                                data = Events2), 
-                   "Events imported: 2")
+    n_imported <- importEvents(rcon, 
+                               data = Events2)
+    expect_equal(n_imported, "2")
     
     rcon$refresh_projectInformation()
     
@@ -215,8 +215,8 @@ test_that(
     
     # Now Clean up from the test
     rcon$refresh_arms()
-    expect_message(deleteArms(rcon, arms = 10:11), 
-                   "Arms Deleted: 10, 11")
+    n_deleted <- deleteArms(rcon, arms = 10:11)
+    expect_equal(n_deleted, "2")
   }
 )
 
@@ -232,13 +232,13 @@ test_that(
                  0)
     
     # To be considered 'longitudinal', both arms and events must be defined.
-    expect_message(importArms(rcon, 
-                              data = Arms), 
-                   "Arms imported: 3")
+    n_imported <- importArms(rcon, 
+                             data = Arms)
+    expect_equal(n_imported, "3")
     
-    expect_message(importEvents(rcon, 
-                                data = Events), 
-                   "Events imported: 3")
+    n_imported <- importEvents(rcon, 
+                               data = Events)
+    expect_equal(n_imported, "3")
     
     rcon$refresh_projectInformation()
     
@@ -246,13 +246,13 @@ test_that(
                  Arms)
     
     # import the additional arms
-    expect_message(importArms(rcon, 
-                              data = Arms2), 
-                   "Arms imported: 2")
+    n_imported <- importArms(rcon, 
+                             data = Arms2)
+    expect_equal(n_imported, "2")
     
-    expect_message(importEvents(rcon, 
-                                data = Events2), 
-                   "Events imported: 2")
+    n_imported <- importEvents(rcon, 
+                               data = Events2)
+    expect_equal(n_imported, "2")
     
     rcon$refresh_projectInformation()
     
@@ -264,18 +264,18 @@ test_that(
     
     # Delete only arms 3 and 10
     
-    expect_message(deleteArms(rcon, 
-                              arms = c(3, 10)), 
-                   "Arms Deleted: 3, 10")
+    n_deleted <- deleteArms(rcon, 
+                            arms = c(3, 10))
+    expect_equal(n_deleted, "2")
     
     expect_data_frame(exportArms(rcon), 
                       nrows = 3, 
                       ncols = 2)
     
     # clean up
-    expect_message(deleteArms(rcon, 
-                              arms = c(1, 2, 11)), 
-                   "Arms Deleted: 1, 2, 11")
+    n_deleted <- deleteArms(rcon, 
+                            arms = c(1, 2, 11))
+    expect_equal(n_deleted, "3")
     
     importProjectInformation(rcon, 
                              data = data.frame(is_longitudinal = 0))

--- a/tests/testthat/test-107-eventsMethods-Functionality.R
+++ b/tests/testthat/test-107-eventsMethods-Functionality.R
@@ -32,22 +32,22 @@ test_that(
     # We start start from an empty classic project. We need to make it
     # longitudinal
     
-    expect_message(importProjectInformation(rcon, 
-                                            data.frame(is_longitudinal = 1)), 
-                   "Fields updated: 1")
+    n_imported <- importProjectInformation(rcon, 
+                                           data.frame(is_longitudinal = 1))
+    expect_equal(n_imported, "1")
     
     # Because no arms or events are defined, it still registers as non-longitudinal
     expect_equal(rcon$projectInformation()$is_longitudinal, 
                  0)
 
     # To be considered 'longitudinal', both arms and events must be defined.
-    expect_message(importArms(rcon, 
-                              data = Arms), 
-                   "Arms imported: 3")
+    n_imported <- importArms(rcon, 
+                             data = Arms) 
+    expect_equal(n_imported, "3")
     
-    expect_message(importEvents(rcon, 
-                                data = Events), 
-                   "Events imported: 3")
+    n_imported <- importEvents(rcon, 
+                               data = Events)
+    expect_equal(n_imported, "3")
     
     rcon$refresh_projectInformation()
     
@@ -61,22 +61,22 @@ test_that(
                       nrows = 3)
     
     # delete the Arms
-    expect_message(deleteEvents(rcon, 
-                                events = c("event_1_arm_1", 
-                                           "event_1_arm_2", 
-                                           "event_1_arm_3")), 
-                   "Events deleted: 3")
+    n_deleted <- deleteEvents(rcon, 
+                              events = c("event_1_arm_1", 
+                                         "event_1_arm_2", 
+                                         "event_1_arm_3"))
+    expect_equal(n_deleted, "3")
     
     # backward compatible with event_data argument
-    expect_message(importEvents(rcon, 
-                                event_data = Events), 
-                   "Events imported: 3")
+    n_imported <- importEvents(rcon, 
+                               event_data = Events)
+    expect_equal(n_imported, "3")
     
-    expect_message(deleteEvents(rcon, 
-                                events = c("event_1_arm_1", 
-                                           "event_1_arm_2", 
-                                           "event_1_arm_3")), 
-                   "Events deleted: 3")
+    n_deleted <- deleteEvents(rcon, 
+                              events = c("event_1_arm_1", 
+                                         "event_1_arm_2", 
+                                         "event_1_arm_3"))
+    expect_equal(n_deleted, "3")
     
     rcon$refresh_projectInformation()
     
@@ -99,13 +99,13 @@ test_that(
                  0)
     
     # To be considered 'longitudinal', both arms and events must be defined.
-    expect_message(importArms(rcon, 
-                              data = Arms), 
-                   "Arms imported: 3")
+    n_imported <- importArms(rcon, 
+                             data = Arms)
+    expect_equal(n_imported, "3")
     
-    expect_message(importEvents(rcon, 
-                                data = Events), 
-                   "Events imported: 3")
+    n_imported <- importEvents(rcon, 
+                               data = Events)
+    expect_equal(n_imported, "3")
     
     rcon$refresh_projectInformation()
     
@@ -120,10 +120,10 @@ test_that(
                                                "event_12"), 
                                 arm_num = 1:3)
     
-    expect_message(importEvents(rcon, 
-                                data = OverrideEvent, 
-                                override = TRUE), 
-                   "Events imported: 3")
+    n_imported <- importEvents(rcon, 
+                               data = OverrideEvent, 
+                               override = TRUE)
+    expect_equal(n_imported, "3")
     
     rcon$refresh_events()
     
@@ -137,8 +137,8 @@ test_that(
     
     # Now Clean up from the test
     rcon$refresh_arms()
-    expect_message(deleteArms(rcon, arms = 1:3), 
-                   "Arms Deleted: 1, 2, 3")
+    n_deleted <- deleteArms(rcon, arms = 1:3)
+    expect_equal(n_deleted, "3")
   }
 )
 
@@ -154,13 +154,13 @@ test_that(
                  0)
     
     # To be considered 'longitudinal', both arms and events must be defined.
-    expect_message(importArms(rcon, 
-                              data = Arms), 
-                   "Arms imported: 3")
+    n_imported <- importArms(rcon, 
+                             data = Arms)
+    expect_equal(n_imported, "3")
     
-    expect_message(importEvents(rcon, 
-                                data = Events), 
-                   "Events imported: 3")
+    n_imported <- importEvents(rcon, 
+                               data = Events)
+    expect_equal(n_imported, "3")
     
     rcon$refresh_projectInformation()
     
@@ -169,13 +169,13 @@ test_that(
                       nrows = 3)
     
     # import the additional events
-    expect_message(importArms(rcon, 
-                              data = Arms2), 
-                   "Arms imported: 2")
+    n_imported <- importArms(rcon, 
+                             data = Arms2)
+    expect_equal(n_imported, "2")
     
-    expect_message(importEvents(rcon, 
-                                data = Events2), 
-                   "Events imported: 2")
+    n_imported <- importEvents(rcon, 
+                               data = Events2)
+    expect_equal(n_imported, "2")
     
     # Confirm that all of the arms are present.
     expect_data_frame(exportEvents(rcon), 
@@ -186,19 +186,19 @@ test_that(
     rcon$refresh_events()
     # Delete only arms 3 and 10
     
-    expect_message(deleteEvents(rcon, 
-                                events = c("event_1_arm_3", 
-                                           "event_x_arm_10")), 
-                   "Events deleted: 2")
+    n_deleted <- deleteEvents(rcon, 
+                              events = c("event_1_arm_3", 
+                                         "event_x_arm_10"))
+    expect_equal(n_deleted, "2")
     
     expect_data_frame(exportEvents(rcon), 
                       nrows = 3, 
                       ncols = 5)
     
     # clean up
-    expect_message(deleteArms(rcon, 
-                              arms = c(1, 2, 3, 10, 11)), 
-                   "Arms Deleted: 1, 2, 3, 10, 11")
+    n_deleted <- deleteArms(rcon, 
+                            arms = c(1, 2, 11))
+    expect_equal(n_deleted, "3")
     
     importProjectInformation(rcon, 
                              data.frame(is_longitudinal = 0))

--- a/tests/testthat/test-108-metadataMethods-Functionality.R
+++ b/tests/testthat/test-108-metadataMethods-Functionality.R
@@ -12,10 +12,9 @@ test_that(
     
     orig_instrument <- unique(MetaData$form_name)
     
-    expect_message(importMetaData(rcon = rcon, 
-                                  data = MetaData), 
-                   sprintf("Fields Imported: %s", 
-                           nrow(MetaData)))
+    n_imported <- importMetaData(rcon = rcon, 
+                                 data = MetaData)
+    expect_equal(n_imported, as.character(nrow(MetaData)))
     
     
     expect_data_frame(rcon$metadata(), 
@@ -28,10 +27,10 @@ test_that(
     NextMetaData <- MetaData[1:10, ]
     
     # Verify behaviors under refresh = FALSE
-    expect_message(importMetaData(rcon, 
-                                  NextMetaData, 
-                                  refresh = FALSE), 
-                   "Fields Imported: 10")
+    n_imported <- importMetaData(rcon, 
+                                 NextMetaData, 
+                                 refresh = FALSE)
+    expect_equal(n_imported, "10")
     
     expect_data_frame(rcon$metadata(), 
                       nrows = nrow(MetaData))

--- a/tests/testthat/test-109-instrumentMethods-Functionality.R
+++ b/tests/testthat/test-109-instrumentMethods-Functionality.R
@@ -120,17 +120,16 @@ test_that(
     ArmOneMapping <- Mapping[Mapping$arm_num == 1, ]
 
     # Import a subset of mappings
-    expect_message(importMappings(rcon,
-                                  ArmOneMapping),
-                   sprintf("Mappings imported: %s", nrow(ArmOneMapping)))
+    n_imported <- importMappings(rcon,
+                                 ArmOneMapping)
+    expect_equal(n_imported, as.character(nrow(ArmOneMapping)))
 
     expect_equal(ArmOneMapping,
                  rcon$mapping())
 
-    expect_message(importMappings(rcon,
-                                  Mapping,
-                                  refresh = FALSE),
-                   sprintf("Mappings imported: %s", nrow(Mapping)))
+    importMappings(rcon,
+                   Mapping,
+                   refresh = FALSE)
 
     expect_data_frame(rcon$mapping(),
                       nrows = nrow(ArmOneMapping))
@@ -148,54 +147,69 @@ test_that(
 test_that(
   "Blank data collection sheet",
   {
-    expect_message(exportPdf(rcon,
-                             dir = tempdir(),
-                             events = "event_1_arm_1",
-                             instruments = "multiple_choice"),
-                   "The file was saved to.+blank.pdf")
+    temp_dir <- tempdir()
+    save_to <- exportPdf(rcon,
+                         dir = temp_dir,
+                         events = "event_1_arm_1",
+                         instruments = "multiple_choice")
+    expect_equal(save_to, 
+                 file.path(temp_dir, 
+                           "redcap_forms_download_blank.pdf"))
   }
 )
 
 test_that(
   "Download all instrument forms (blank)",
   {
-    expect_message(exportPdf(rcon,
-                             dir = tempdir(),
-                             events = "event_1_arm_1"),
-                   "The file was saved to.+blank.pdf")
+    temp_dir <- tempdir()
+    save_to <- exportPdf(rcon,
+                         dir = temp_dir,
+                         events = "event_1_arm_1")
+    expect_equal(save_to, 
+                 file.path(temp_dir, 
+                           "redcap_forms_download_blank.pdf"))
   }
 )
 
 test_that(
   "exportPdf export the instrument PDF for a record",
   {
-    expect_message(exportPdf(rcon,
-                             dir = tempdir(),
-                             record = 1,
-                             events = "event_1_arm_1",
-                             instruments = "multiple_choice"),
-                   "The file was saved to.+record[_]1.pdf")
+    temp_dir <- tempdir()
+    save_to <- exportPdf(rcon,
+                         dir = temp_dir,
+                         record = 1,
+                         events = "event_1_arm_1",
+                         instruments = "multiple_choice")
+    expect_equal(save_to, 
+                 file.path(temp_dir, 
+                           "redcap_forms_download_record_1.pdf"))
   }
 )
 
 test_that(
   "exportPdf export all instruments for a record",
   {
-    expect_message(exportPdf(rcon,
-                             dir = tempdir(),
-                             record = 1,
-                             events = "event_1_arm_1"),
-                   "The file was saved to.+record[_]1.pdf")
+    temp_dir <- tempdir()
+    save_to <- exportPdf(rcon,
+                         dir = temp_dir,
+                         record = 1,
+                         events = "event_1_arm_1")
+    expect_equal(save_to, 
+                 file.path(temp_dir, 
+                           "redcap_forms_download_record_1.pdf"))
   }
 )
 
 test_that(
   "all instruments with data from all records",
   {
-    expect_message(exportPdf(rcon,
-                             dir = tempdir(),
-                             all_records = TRUE),
-                   "The file was saved to.+all[_]records.pdf")
+    temp_dir <- tempdir()
+    save_to <- exportPdf(rcon,
+                         dir = temp_dir,
+                         all_records = TRUE)
+    expect_equal(save_to, 
+                 file.path(temp_dir, 
+                           "redcap_forms_download_all_records.pdf"))
   }
 )
 

--- a/tests/testthat/test-110-repeatingInstruments-Functionality.R
+++ b/tests/testthat/test-110-repeatingInstruments-Functionality.R
@@ -53,9 +53,9 @@ test_that(
     Repeat <- data.frame(event_name = "event_1_arm_1", 
                          form_name = "repeating_instrument")
     
-    expect_message(importRepeatingInstrumentsEvents(rcon, 
-                                                    data = Repeat), 
-                   "Rows imported: 1")
+    n_imported <- importRepeatingInstrumentsEvents(rcon, 
+                                                   data = Repeat)
+    expect_equal(n_imported, "1")
     
     rcon$refresh_projectInformation()
     rcon$refresh_repeatInstrumentEvent()
@@ -70,9 +70,9 @@ test_that(
     
     
     # Now let's back out the changes
-    expect_message(importRepeatingInstrumentsEvents(rcon, 
-                                                    REDCAP_REPEAT_INSTRUMENT_STRUCTURE), 
-                   "Rows imported: 0")
+    n_imported <- importRepeatingInstrumentsEvents(rcon, 
+                                                   REDCAP_REPEAT_INSTRUMENT_STRUCTURE)
+    expect_equal(n_imported, "0")
   
     expect_data_frame(exportRepeatingInstrumentsEvents(rcon), 
                       nrows = 0)

--- a/tests/testthat/test-301-fileMethods-Functionality.R
+++ b/tests/testthat/test-301-fileMethods-Functionality.R
@@ -6,41 +6,38 @@ test_that(
   "import, export, and delete a file in a longitudinal project",
   {
     local_reproducible_output(width = 200)
-    expect_message(
+    expect_true(
       importFiles(rcon,
                   file = local_file,
                   record = "1",
                   field = "file_upload_test",
                   event = "event_1_arm_1",
                   overwrite = FALSE,
-                  repeat_instance = NULL),
-      "The file was successfully uploaded"
+                  repeat_instance = NULL)
     )
 
 
     temp_dir <- tempdir()
 
     # Export the file
-    expect_message(
-      exportFiles(rcon,
-                  record = "1",
-                  field = "file_upload_test",
-                  event = "event_1_arm_1",
-                  dir = temp_dir,
-                  file_prefix = TRUE),
-      "The file was saved to '.+1-event_1_arm_1-FileForImportExportTesting.txt"
-    )
+    save_to <- exportFiles(rcon,
+                           record = "1",
+                           field = "file_upload_test",
+                           event = "event_1_arm_1",
+                           dir = temp_dir,
+                           file_prefix = TRUE)
+    expect_true(grepl(".+1-event_1_arm_1-FileForImportExportTesting.txt", 
+                      save_to))
 
     # And now import it again with an overwrite
-    expect_message(
+    expect_true(
       importFiles(rcon,
                   file = local_file,
                   record = "1",
                   field = "file_upload_test",
                   event = "event_1_arm_1",
                   overwrite = TRUE,
-                  repeat_instance = NULL),
-      "The file was successfully uploaded"
+                  repeat_instance = NULL)
     )
 
     # Attempt an import without overwrite = TRUE. Results in error
@@ -56,12 +53,11 @@ test_that(
     )
 
     # Delete the file
-    expect_message(
+    expect_true(
       deleteFiles(rcon,
                   record = "1",
                   field = "file_upload_test",
-                  event = "event_1_arm_1"),
-      "The file was successfully deleted"
+                  event = "event_1_arm_1")
     )
   }
 )
@@ -88,42 +84,41 @@ test_that(
   "import, export, and delete a file in a longitudinal project",
   {
     local_reproducible_output(width = 200)
-    expect_message(
+    expect_true(
       importFiles(rcon,
                   file = local_file,
                   record = "1",
                   field = "file_upload_test",
                   event = "event_1_arm_1",
                   overwrite = FALSE,
-                  repeat_instance = 1),
-      "The file was successfully uploaded"
+                  repeat_instance = 1)
     )
 
 
     temp_dir <- tempdir()
 
     # Export the file
-    expect_message(
-      exportFiles(rcon,
-                  record = "1",
-                  field = "file_upload_test",
-                  event = "event_1_arm_1",
-                  repeat_instance = 1,
-                  dir = temp_dir,
-                  file_prefix = TRUE),
-      "The file was saved to '.+1-event_1_arm_1-FileForImportExportTesting.txt"
+    save_to <- exportFiles(rcon,
+                           record = "1",
+                           field = "file_upload_test",
+                           event = "event_1_arm_1",
+                           repeat_instance = 1,
+                           dir = temp_dir,
+                           file_prefix = TRUE)
+    expect_true(
+      grepl(".+1-event_1_arm_1-FileForImportExportTesting.txt", 
+            save_to)
     )
 
     # And now import it again with an overwrite
-    expect_message(
+    expect_true(
       importFiles(rcon,
                   file = local_file,
                   record = "1",
                   field = "file_upload_test",
                   event = "event_1_arm_1",
                   overwrite = TRUE,
-                  repeat_instance = 1),
-      "The file was successfully uploaded"
+                  repeat_instance = 1)
     )
 
     # Attempt an import without overwrite = TRUE. Results in error
@@ -139,13 +134,12 @@ test_that(
     )
 
     # Delete the file
-    expect_message(
+    expect_true(
       deleteFiles(rcon,
                   record = "1",
                   field = "file_upload_test",
                   event = "event_1_arm_1",
-                  repeate_instance = 1),
-      "The file was successfully deleted"
+                  repeate_instance = 1)
     )
   }
 )

--- a/tests/testthat/test-304-fileRepository-BulkFileMethods-Functionality.R
+++ b/tests/testthat/test-304-fileRepository-BulkFileMethods-Functionality.R
@@ -87,11 +87,10 @@ test_that(
                          dir_create = TRUE,
                          recursive = TRUE)
     
-    expect_message(Deleted <- deleteFileRepository(rcon, 
-                                                   folder_id = 0, 
-                                                   recursive = TRUE, 
-                                                   confirm = "yes"), 
-                   "File deleted[:]")
+    Deleted <- deleteFileRepository(rcon, 
+                                    folder_id = 0, 
+                                    recursive = TRUE, 
+                                    confirm = "yes")
     
     expect_data_frame(Deleted, 
                       ncols = 4)


### PR DESCRIPTION
This took less time than I thought it would.

* Removes all messages issued with returns.
* Invisibly returns the response for most import or delete objects, instead of issuing a message.

Tests have been updated to not look for messages, but still test for the correct number of changes.

Check passes with no errors, warnings, or notes.