### PR TITLE
implement repeat_instance in exportFiles

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,7 @@ A future release of version 3.0.0 will introduce several breaking changes!
 * Additional timeout trap for request retry strategy. 
 * Reports of data failing validation checks now include a link to the form with the failing data.
 * Major cleanup to remove messages on successful function execution. Many return values are changed to be consistent and be TRUE/FALSE if possible.
+* Bug fix: The repeat_instance argument of exportFiles is now included in the API call.
 
 ## 2.8.0
 
@@ -27,10 +28,9 @@ A future release of version 3.0.0 will introduce several breaking changes!
 * Added renameRecord function.
 * Fixed issue with preserving missing values in preparing checkbox fields for import
 * Added `default_cast_no_factor`, a list of casting functions that may be used to cast fields without casting any fields to factors.  It comes with an equivalent alias `default_cast_character`.
-* Documentation has been standardized. Related methods are now documented in the same
-help file. 
+* Documentation has been standardized. Related methods are now documented in the same help file. 
 * Add several functions for exporting Survey links and return codes
-* Replaced depricated function with_mock with with_mocked_bindings
+* Replaced deprecated function with_mock with with_mocked_bindings
 
 ## 2.7.5
 

--- a/R/exportFiles.R
+++ b/R/exportFiles.R
@@ -132,7 +132,8 @@ exportFiles.redcapApiConnection <- function(rcon,
                returnFormat = 'csv',
                record = record,
                field = field, 
-               event = event)
+               event = event, 
+               repeat_instance = repeat_instance)
   
   body <- body[lengths(body) > 0]
   

--- a/tests/testthat/test-301-fileMethods-Functionality.R
+++ b/tests/testthat/test-301-fileMethods-Functionality.R
@@ -141,6 +141,9 @@ test_that(
                   event = "event_1_arm_1",
                   repeat_instance = 1)
     )
+    
+    lapply(list.files(temp_dir), 
+           unlink)
   }
 )
 
@@ -196,5 +199,8 @@ test_that(
                             field = "file_upload_test", 
                             event = "event_1_arm_1", 
                             repeat_instance = 2))
+    
+    # clean up
+    unlink(temp_file)
   }
 )

--- a/tests/testthat/test-301-fileMethods-Functionality.R
+++ b/tests/testthat/test-301-fileMethods-Functionality.R
@@ -139,7 +139,62 @@ test_that(
                   record = "1",
                   field = "file_upload_test",
                   event = "event_1_arm_1",
-                  repeate_instance = 1)
+                  repeat_instance = 1)
     )
+  }
+)
+
+test_that(
+  "Files imported/exported from repeat instances > 1", 
+  {
+    temp_file <- tempfile(fileext = ".txt")
+    file.copy(local_file, temp_file)
+    
+    expect_true(importFiles(rcon, 
+                            file = local_file, 
+                            record = "1", 
+                            field = "file_upload_test", 
+                            event = "event_1_arm_1", 
+                            repeat_instance = 1))
+    
+    expect_true(importFiles(rcon, 
+                            file = temp_file, 
+                            record = "1", 
+                            field = "file_upload_test", 
+                            event = "event_1_arm_1", 
+                            repeat_instance = 2))
+    
+    target_dir <- tempdir()
+    
+    file1 <- exportFiles(rcon, 
+                         record = "1", 
+                         field = "file_upload_test", 
+                         event = "event_1_arm_1", 
+                         dir = target_dir, 
+                         repeat_instance = 1)
+    expect_true(file.exists(file1))
+    expect_true(grepl("FileForImportExportTesting.txt", file1))
+    
+    file2 <- exportFiles(rcon, 
+                         record = "1", 
+                         field = "file_upload_test", 
+                         event = "event_1_arm_1", 
+                         dir = target_dir, 
+                         repeat_instance = 2)
+    
+    expect_true(file.exists(file2))
+    expect_true(grepl(basename(temp_file), file2))
+    
+    expect_true(deleteFiles(rcon, 
+                            record = "1", 
+                            field = "file_upload_test", 
+                            event = "event_1_arm_1", 
+                            repeat_instance = 1))
+    
+    expect_true(deleteFiles(rcon, 
+                            record = "1", 
+                            field = "file_upload_test", 
+                            event = "event_1_arm_1", 
+                            repeat_instance = 2))
   }
 )


### PR DESCRIPTION
Addresses #245 

* Implements repeat_instance in the API call of exportFiles.
* Adds tests to explicitly test that files can be imported, exported, and deleted from repeat instances greater than 1.
* NEWS updated

Check passes with no warnings, notes, or errors.

All tests passing.