### PR TITLE
strip form_name check

### DIFF
--- a/R/constructLinkToRedcapForm.R
+++ b/R/constructLinkToRedcapForm.R
@@ -66,7 +66,6 @@ constructLinkToRedcapForm.redcapApiConnection <- function(rcon,
                           add = coll)
   
   checkmate::assert_character(x = form_name,
-                              any.missing = FALSE,
                               add = coll)
   
   checkmate::assert_character(x = record_id,
@@ -140,7 +139,6 @@ constructLinkToRedcapForm.redcapOfflineConnection <- function(rcon,
                           add = coll)
   
   checkmate::assert_character(x = form_name,
-                              any.missing = FALSE,
                               add = coll)
   
   checkmate::assert_character(x = record_id,


### PR DESCRIPTION
Remove the need for a form_name on record link construction.