### PR TITLE
detailed field labels for checkbox fields. 

### DIFF
--- a/tests/testthat/test-200-exportTypedRecords-Functionality.R
+++ b/tests/testthat/test-200-exportTypedRecords-Functionality.R
@@ -130,6 +130,19 @@ test_that(
     expect_equal(attr(rec$date_dmy_test, "units"), "time")
   }
 )
+
+test_that(
+  "Checkbox fields labels include the choice", 
+  {
+    expect_equal(attr(rec$checkbox_test___x, "label"), 
+                 "Checkbox Example (choice=Guitar)")
+    expect_equal(attr(rec$checkbox_test___y, "label"), 
+                 "Checkbox Example (choice=Ukulele)")
+    expect_equal(attr(rec$checkbox_test___z, "label"), 
+                 "Checkbox Example (choice=Mandolin)")
+  }
+)
+
 rm(rec)
 
 #####################################################################


### PR DESCRIPTION
Addresses #301 

Checkbox field labels take the form `[Field Label] (choice=[Choice Label])`

Will also be useful in getting #285 up to standard.

Should also help with #299 