### PR TITLE
Iconv 290 297 314

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: redcapAPI
 Type: Package
 Title: Interface to 'REDCap'
-Version: 2.8.3
+Version: 2.8.4
 Authors@R: c(
     person("Shawn", "Garbett", email = "shawn.garbett@vumc.org",
            comment = c(ORCID="0000-0003-4079-5621"),

--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,10 @@ A future release of version 3.0.0 will introduce several breaking changes!
 * The `exportProjectInfo` and `exportBundle` functions are being discontinued. Their functionality is replaced by caching values on the connection object.
 * The `cleanseMetaData` function is being discontinued.
 
+## 2.8.4
+
+* Patch to reading HTTP data. When non UTF-8 characters are sent, they get mapped to '□'.
+
 ## 2.8.3
 
 * Patch to date range handling that was breaking on new REDCap projects since version 14.0.2 of the REDCap server.

--- a/R/createFileRepositoryFolder.R
+++ b/R/createFileRepositoryFolder.R
@@ -188,9 +188,8 @@ createFileRepositoryFolder.redcapApiConnection <- function(rcon,
   }
   
   # Prepare Output --------------------------------------------------
-  NewFolder <- utils::read.csv(text = .safe_as_character_response(response), 
-                               stringsAsFactors = FALSE, 
-                               na.strings = "")
+  NewFolder <- as.data.frame(response)
+
   NewFolder$name <- rep(name, nrow(NewFolder))
   
   NewFolder

--- a/R/createFileRepositoryFolder.R
+++ b/R/createFileRepositoryFolder.R
@@ -188,7 +188,7 @@ createFileRepositoryFolder.redcapApiConnection <- function(rcon,
   }
   
   # Prepare Output --------------------------------------------------
-  NewFolder <- utils::read.csv(text = as.character(response), 
+  NewFolder <- utils::read.csv(text = .safe_as_character_response(response), 
                                stringsAsFactors = FALSE, 
                                na.strings = "")
   NewFolder$name <- rep(name, nrow(NewFolder))

--- a/R/exportArms.R
+++ b/R/exportArms.R
@@ -69,7 +69,7 @@ exportArms.redcapApiConnection <- function(rcon,
                  error_handling = error_handling)
   }
   
-  utils::read.csv(text = as.character(response), 
+  utils::read.csv(text = .safe_as_character_response(response), 
                   stringsAsFactors = FALSE,
                   na.strings = "")
 }

--- a/R/exportArms.R
+++ b/R/exportArms.R
@@ -69,7 +69,5 @@ exportArms.redcapApiConnection <- function(rcon,
                  error_handling = error_handling)
   }
   
-  utils::read.csv(text = .safe_as_character_response(response), 
-                  stringsAsFactors = FALSE,
-                  na.strings = "")
+  as.data.frame(response)
 }

--- a/R/exportDags.R
+++ b/R/exportDags.R
@@ -58,7 +58,5 @@ exportDags.redcapApiConnection <- function(rcon,
   
   if (response$status_code != 200) return(redcapError(response, error_handling))
   
-  utils::read.csv(text = .safe_as_character_response(response), 
-                  na.strings = "",
-                  stringsAsFactors = FALSE)
+  as.data.frame(response)
 }

--- a/R/exportDags.R
+++ b/R/exportDags.R
@@ -58,7 +58,7 @@ exportDags.redcapApiConnection <- function(rcon,
   
   if (response$status_code != 200) return(redcapError(response, error_handling))
   
-  utils::read.csv(text = as.character(response), 
+  utils::read.csv(text = .safe_as_character_response(response), 
                   na.strings = "",
                   stringsAsFactors = FALSE)
 }

--- a/R/exportEvents.R
+++ b/R/exportEvents.R
@@ -86,7 +86,7 @@ exportEvents.redcapApiConnection <- function(rcon,
   if (trimws(as.character(response)) == ""){
     REDCAP_EVENT_STRUCTURE
   } else {
-    utils::read.csv(text = as.character(response),
+    utils::read.csv(text = .safe_as_character_response(response),
                     stringsAsFactors = FALSE,
                     na.strings = "")
   }

--- a/R/exportEvents.R
+++ b/R/exportEvents.R
@@ -86,8 +86,6 @@ exportEvents.redcapApiConnection <- function(rcon,
   if (trimws(as.character(response)) == ""){
     REDCAP_EVENT_STRUCTURE
   } else {
-    utils::read.csv(text = .safe_as_character_response(response),
-                    stringsAsFactors = FALSE,
-                    na.strings = "")
+    as.data.frame(response)
   }
 }

--- a/R/exportFieldNames.R
+++ b/R/exportFieldNames.R
@@ -138,7 +138,7 @@ exportFieldNames.redcapApiConnection <- function(rcon,
 
   }
   
-  utils::read.csv(text = as.character(response), 
+  utils::read.csv(text = .safe_as_character_response(response), 
                   stringsAsFactors = FALSE,
                   na.strings = "")
 }

--- a/R/exportFieldNames.R
+++ b/R/exportFieldNames.R
@@ -138,9 +138,7 @@ exportFieldNames.redcapApiConnection <- function(rcon,
 
   }
   
-  utils::read.csv(text = .safe_as_character_response(response), 
-                  stringsAsFactors = FALSE,
-                  na.strings = "")
+  as.data.frame(response)
 }
 
 # Unexported --------------------------------------------------------

--- a/R/exportInstruments.R
+++ b/R/exportInstruments.R
@@ -90,7 +90,5 @@ exportInstruments.redcapApiConnection <- function(rcon,
   
   if (response$status_code != 200) return(redcapError(response, error_handling))
   
-  utils::read.csv(text = .safe_as_character_response(response), 
-                  stringsAsFactors = FALSE, 
-                  na.strings = "")
+  as.data.frame(response)
 }

--- a/R/exportInstruments.R
+++ b/R/exportInstruments.R
@@ -90,7 +90,7 @@ exportInstruments.redcapApiConnection <- function(rcon,
   
   if (response$status_code != 200) return(redcapError(response, error_handling))
   
-  utils::read.csv(text = as.character(response), 
+  utils::read.csv(text = .safe_as_character_response(response), 
                   stringsAsFactors = FALSE, 
                   na.strings = "")
 }

--- a/R/exportLogging.R
+++ b/R/exportLogging.R
@@ -160,9 +160,7 @@ exportLogging.redcapApiConnection <- function(rcon,
                  error_handling = error_handling)
   } 
   
-  Log <- utils::read.csv(text = .safe_as_character_response(response),
-                         stringsAsFactors = FALSE,
-                         na.strings = "")
+  Log <- as.data.frame(response)
   
   # Format and return data ------------------------------------------
   Log$timestamp <- as.POSIXct(Log$timestamp, 

--- a/R/exportLogging.R
+++ b/R/exportLogging.R
@@ -160,7 +160,7 @@ exportLogging.redcapApiConnection <- function(rcon,
                  error_handling = error_handling)
   } 
   
-  Log <- utils::read.csv(text = as.character(response),
+  Log <- utils::read.csv(text = .safe_as_character_response(response),
                          stringsAsFactors = FALSE,
                          na.strings = "")
   

--- a/R/exportMappings.R
+++ b/R/exportMappings.R
@@ -77,7 +77,5 @@ exportMappings.redcapApiConnection <- function(rcon,
   
   if (response$status_code != 200) return(redcapError(response, error_handling))
   
-  utils::read.csv(text = .safe_as_character_response(response), 
-                  stringsAsFactors = FALSE, 
-                  na.strings = "")
+  as.data.frame(response)
 }

--- a/R/exportMappings.R
+++ b/R/exportMappings.R
@@ -77,7 +77,7 @@ exportMappings.redcapApiConnection <- function(rcon,
   
   if (response$status_code != 200) return(redcapError(response, error_handling))
   
-  utils::read.csv(text = as.character(response), 
+  utils::read.csv(text = .safe_as_character_response(response), 
                   stringsAsFactors = FALSE, 
                   na.strings = "")
 }

--- a/R/exportProjectInformation.R
+++ b/R/exportProjectInformation.R
@@ -59,7 +59,5 @@ exportProjectInformation.redcapApiConnection <- function(rcon,
   
   if (response$status_code != 200) return(redcapError(response, error_handling))
   
-  utils::read.csv(text = .safe_as_character_response(response), 
-                  stringsAsFactors = FALSE, 
-                  na.strings="")
+  as.data.frame(response)
 }

--- a/R/exportProjectInformation.R
+++ b/R/exportProjectInformation.R
@@ -59,7 +59,7 @@ exportProjectInformation.redcapApiConnection <- function(rcon,
   
   if (response$status_code != 200) return(redcapError(response, error_handling))
   
-  utils::read.csv(text = as.character(response), 
+  utils::read.csv(text = .safe_as_character_response(response), 
                   stringsAsFactors = FALSE, 
                   na.strings="")
 }

--- a/R/exportRecordsTyped.R
+++ b/R/exportRecordsTyped.R
@@ -660,7 +660,7 @@ exportRecordsTyped.redcapOfflineConnection <- function(rcon,
     return(data.frame())
   }
   
-  utils::read.csv(text = as.character(response), 
+  utils::read.csv(text = .safe_as_character_response(response), 
                   stringsAsFactors = FALSE, 
                   na.strings = "", 
                   colClasses = "character", 
@@ -699,7 +699,7 @@ exportRecordsTyped.redcapOfflineConnection <- function(rcon,
       return(data.frame())
     }
     
-    records <- utils::read.csv(text = as.character(record_response), 
+    records <- utils::read.csv(text = .safe_as_character_response(record_response), 
                                stringsAsFactors = FALSE, 
                                na.strings = "", 
                                sep = csv_delimiter)

--- a/R/exportRecordsTyped.R
+++ b/R/exportRecordsTyped.R
@@ -660,11 +660,9 @@ exportRecordsTyped.redcapOfflineConnection <- function(rcon,
     return(data.frame())
   }
   
-  utils::read.csv(text = .safe_as_character_response(response), 
-                  stringsAsFactors = FALSE, 
-                  na.strings = "", 
-                  colClasses = "character", 
-                  sep = csv_delimiter)
+  as.data.frame(response,  
+                colClasses = "character", 
+                sep = csv_delimiter)
 }
 
 # .exportRecordsTyped_Batched ---------------------------------------
@@ -699,10 +697,7 @@ exportRecordsTyped.redcapOfflineConnection <- function(rcon,
       return(data.frame())
     }
     
-    records <- utils::read.csv(text = .safe_as_character_response(record_response), 
-                               stringsAsFactors = FALSE, 
-                               na.strings = "", 
-                               sep = csv_delimiter)
+    records <- as.data.frame(record_response, sep = csv_delimiter)
     records <- unique(records[[target_field]])
   }
 

--- a/R/exportRepeatingInstrumentsEvents.R
+++ b/R/exportRepeatingInstrumentsEvents.R
@@ -69,7 +69,7 @@ exportRepeatingInstrumentsEvents.redcapApiConnection <- function(rcon,
                  error_handling = error_handling)
   }
   
-  utils::read.csv(text = as.character(response), 
+  utils::read.csv(text = .safe_as_character_response(response), 
                   stringsAsFactors = FALSE,
                   na.strings = "")
 }

--- a/R/exportRepeatingInstrumentsEvents.R
+++ b/R/exportRepeatingInstrumentsEvents.R
@@ -69,7 +69,5 @@ exportRepeatingInstrumentsEvents.redcapApiConnection <- function(rcon,
                  error_handling = error_handling)
   }
   
-  utils::read.csv(text = .safe_as_character_response(response), 
-                  stringsAsFactors = FALSE,
-                  na.strings = "")
+  as.data.frame(response)
 }

--- a/R/exportReports.R
+++ b/R/exportReports.R
@@ -115,7 +115,7 @@ exportReports.redcapApiConnection <- function(rcon,
   
   if (response$status_code != 200) redcapError(response, error_handling)
   
-  Report <- utils::read.csv(text = as.character(response), 
+  Report <- utils::read.csv(text = .safe_as_character_response(response), 
                             stringsAsFactors = FALSE, 
                             na.strings = "")
   

--- a/R/exportReports.R
+++ b/R/exportReports.R
@@ -115,9 +115,7 @@ exportReports.redcapApiConnection <- function(rcon,
   
   if (response$status_code != 200) redcapError(response, error_handling)
   
-  Report <- utils::read.csv(text = .safe_as_character_response(response), 
-                            stringsAsFactors = FALSE, 
-                            na.strings = "")
+  Report <- as.data.frame(response)
   
    ##################################################################
   # Process the data

--- a/R/exportReportsTyped.R
+++ b/R/exportReportsTyped.R
@@ -109,7 +109,7 @@ exportReportsTyped.redcapApiConnection <- function(rcon,
                           body = c(body, api_param), 
                           config)
   
-  Raw <- utils::read.csv(text = as.character(response), 
+  Raw <- utils::read.csv(text = .safe_as_character_response(response), 
                          na.strings = "", 
                          sep = csv_delimiter,
                          stringsAsFactors = FALSE)

--- a/R/exportReportsTyped.R
+++ b/R/exportReportsTyped.R
@@ -109,10 +109,7 @@ exportReportsTyped.redcapApiConnection <- function(rcon,
                           body = c(body, api_param), 
                           config)
   
-  Raw <- utils::read.csv(text = .safe_as_character_response(response), 
-                         na.strings = "", 
-                         sep = csv_delimiter,
-                         stringsAsFactors = FALSE)
+  Raw <- as.data.frame(response, sep = csv_delimiter)
   
   if (length(drop_fields) > 0){
     Raw <- Raw[!names(Raw) %in% drop_fields]

--- a/R/exportUserDagAssignments.R
+++ b/R/exportUserDagAssignments.R
@@ -65,7 +65,7 @@ exportUserDagAssignments.redcapApiConnection <- function(rcon,
     return(REDCAP_DAG_ASSIGNMENT_STRUCTURE)
   }
   
-  utils::read.csv(text = as.character(response), 
+  utils::read.csv(text = .safe_as_character_response(response), 
                   na.strings = "", 
                   stringsAsFactors = FALSE)
 }

--- a/R/exportUserDagAssignments.R
+++ b/R/exportUserDagAssignments.R
@@ -65,7 +65,5 @@ exportUserDagAssignments.redcapApiConnection <- function(rcon,
     return(REDCAP_DAG_ASSIGNMENT_STRUCTURE)
   }
   
-  utils::read.csv(text = .safe_as_character_response(response), 
-                  na.strings = "", 
-                  stringsAsFactors = FALSE)
+  as.data.frame(response)
 }

--- a/R/exportUserRoleAssignments.R
+++ b/R/exportUserRoleAssignments.R
@@ -64,7 +64,5 @@ exportUserRoleAssignments.redcapApiConnection <- function(rcon,
     return(REDCAP_USER_ROLE_ASSIGNMENT_STRUCTURE)
   }
   
-  utils::read.csv(text = .safe_as_character_response(response), 
-                  na.strings = "", 
-                  stringsAsFactors = FALSE)
+  as.data.frame(response)
 }

--- a/R/exportUserRoleAssignments.R
+++ b/R/exportUserRoleAssignments.R
@@ -64,7 +64,7 @@ exportUserRoleAssignments.redcapApiConnection <- function(rcon,
     return(REDCAP_USER_ROLE_ASSIGNMENT_STRUCTURE)
   }
   
-  utils::read.csv(text = as.character(response), 
+  utils::read.csv(text = .safe_as_character_response(response), 
                   na.strings = "", 
                   stringsAsFactors = FALSE)
 }

--- a/R/exportUserRoles.R
+++ b/R/exportUserRoles.R
@@ -76,7 +76,7 @@ exportUserRoles.redcapApiConnection <- function(rcon,
     return(REDCAP_USER_ROLE_STRUCTURE)
   }
   
-  UserRole <- utils::read.csv(text = as.character(response), 
+  UserRole <- utils::read.csv(text = .safe_as_character_response(response), 
                               na.strings = "", 
                               stringsAsFactors = FALSE)
   

--- a/R/exportUserRoles.R
+++ b/R/exportUserRoles.R
@@ -76,9 +76,7 @@ exportUserRoles.redcapApiConnection <- function(rcon,
     return(REDCAP_USER_ROLE_STRUCTURE)
   }
   
-  UserRole <- utils::read.csv(text = .safe_as_character_response(response), 
-                              na.strings = "", 
-                              stringsAsFactors = FALSE)
+  UserRole <- as.data.frame(response)
   
   # The API returns the forms_export string twice.  We reduce it to once here
   temp <- UserRole$forms_export

--- a/R/exportUsers.R
+++ b/R/exportUsers.R
@@ -78,7 +78,7 @@ exportUsers.redcapApiConnection <- function(rcon,
                  error_handling = error_handling)
   }
   
-  Users <- utils::read.csv(text = as.character(response), 
+  Users <- utils::read.csv(text = .safe_as_character_response(response), 
                            stringsAsFactors = FALSE,
                            na.strings = "")
   

--- a/R/exportUsers.R
+++ b/R/exportUsers.R
@@ -78,9 +78,7 @@ exportUsers.redcapApiConnection <- function(rcon,
                  error_handling = error_handling)
   }
   
-  Users <- utils::read.csv(text = .safe_as_character_response(response), 
-                           stringsAsFactors = FALSE,
-                           na.strings = "")
+  Users <- as.data.frame(response)
   
   Users$forms_export <- 
     sub(",registration[:]\\d{1}.+$", "", Users$forms_export)

--- a/R/importRecords.R
+++ b/R/importRecords.R
@@ -443,7 +443,7 @@ import_records_unbatched <- function(rcon,
   
   if (response$status_code == "200"){
     if (returnContent %in% c("ids", "auto_ids")){
-      utils::read.csv(text = as.character(response), 
+      utils::read.csv(text = .safe_as_character_response(response), 
                na.strings = "", 
                stringsAsFactors = FALSE)
     } else {

--- a/R/importRecords.R
+++ b/R/importRecords.R
@@ -443,9 +443,7 @@ import_records_unbatched <- function(rcon,
   
   if (response$status_code == "200"){
     if (returnContent %in% c("ids", "auto_ids")){
-      utils::read.csv(text = .safe_as_character_response(response), 
-               na.strings = "", 
-               stringsAsFactors = FALSE)
+      as.data.frame(response)
     } else {
       as.character(response)
     }

--- a/R/makeApiCall.R
+++ b/R/makeApiCall.R
@@ -267,10 +267,9 @@ as.data.frame.response <- function(x, stringsAsFactors=FALSE, na.strings = "", .
   mapped <- iconv(readBin(x$content, character()),
                   enc, 'UTF-8', '\U25a1')
   if(grepl('\U25a1', mapped)) warning("Project contains invalid characters. Mapped to '\U25a1'.")
-  Frame <- utils::read.csv(
+  utils::read.csv(
     text             = mapped,
     stringsAsFactors = stringsAsFactors, 
     na.strings       = na.strings,
     ...)
-  Frame
 }

--- a/R/makeApiCall.R
+++ b/R/makeApiCall.R
@@ -262,8 +262,9 @@ makeApiCall <- function(rcon,
 # Helper function to convert responses to character strings without crashing.
 as.data.frame.response <- function(x, stringsAsFactors=FALSE, na.strings = "", ...)
 {
-  enc <- x$headers[["Content-Type"]]
-  if(is.null(enc)) enc <- 'UTF-8'
+  enc <- if(grepl("charset", x$headers[["Content-Type"]]))
+    toupper(sub(".*charset=", "", x$headers[["Content-Type"]])) else
+    'ISO-8859-1' # [Default if unspecified](https://www.w3.org/International/articles/http-charset/index)
   mapped <- iconv(readBin(x$content, character()),
                   enc, 'UTF-8', '\U25a1')
   if(grepl('\U25a1', mapped)) warning("Project contains invalid characters. Mapped to '\U25a1'.")

--- a/R/makeApiCall.R
+++ b/R/makeApiCall.R
@@ -260,7 +260,6 @@ makeApiCall <- function(rcon,
 }
 
 # Helper function to convert responses to character strings without crashing.
-# ASSUMPTION: UTF-8 is the only allowed encoding. 
 as.data.frame.response <- function(x, stringsAsFactors=FALSE, na.strings = "", ...)
 {
   enc <- x$headers[["Content-Type"]]

--- a/R/makeApiCall.R
+++ b/R/makeApiCall.R
@@ -263,7 +263,7 @@ makeApiCall <- function(rcon,
 as.data.frame.response <- function(x, stringsAsFactors=FALSE, na.strings = "", ...)
 {
   enc <- if(grepl("charset", x$headers[["Content-Type"]]))
-    toupper(sub(".*charset=", "", x$headers[["Content-Type"]])) else
+    toupper(sub('.*charset=([^;]+).*', '\\1', x$headers[["Content-Type"]])) else
     'ISO-8859-1' # [Default if unspecified](https://www.w3.org/International/articles/http-charset/index)
   mapped <- iconv(readBin(x$content, character()),
                   enc, 'UTF-8', '\U25a1')

--- a/R/makeApiCall.R
+++ b/R/makeApiCall.R
@@ -261,5 +261,10 @@ makeApiCall <- function(rcon,
 
 # Helper function to convert responses to character strings without crashing.
 # ASSUMPTION: UTF-8 is the only allowed encoding. 
-.safe_as_character_response <- function(x, ...)
-  iconv(readBin(x$content, character()), 'UTF-8', 'UTF-8', '\U25a1')
+as.data.frame.response <- function(x, ...)
+  utils::read.csv(
+    text             = iconv(readBin(x$content, character()),
+                                    'UTF-8', 'UTF-8', '\U25a1'),
+    stringsAsFactors = FALSE, 
+    na.strings       = "",
+    ...)

--- a/R/makeApiCall.R
+++ b/R/makeApiCall.R
@@ -264,10 +264,13 @@ as.data.frame.response <- function(x, stringsAsFactors=FALSE, na.strings = "", .
 {
   enc <- x$headers[["Content-Type"]]
   if(is.null(enc)) enc <- 'UTF-8'
-  utils::read.csv(
-    text             = iconv(readBin(x$content, character()),
-                             enc, 'UTF-8', '\U25a1'),
+  mapped <- iconv(readBin(x$content, character()),
+                  enc, 'UTF-8', '\U25a1')
+  if(grepl('\U25a1', mapped)) warning("Project contains invalid characters. Mapped to '\U25a1'.")
+  Frame <- utils::read.csv(
+    text             = mapped,
     stringsAsFactors = stringsAsFactors, 
     na.strings       = na.strings,
     ...)
+  Frame
 }

--- a/R/makeApiCall.R
+++ b/R/makeApiCall.R
@@ -262,9 +262,13 @@ makeApiCall <- function(rcon,
 # Helper function to convert responses to character strings without crashing.
 # ASSUMPTION: UTF-8 is the only allowed encoding. 
 as.data.frame.response <- function(x, stringsAsFactors=FALSE, na.strings = "", ...)
+{
+  enc <- x$headers[["Content-Type"]]
+  if(is.null(enc)) enc <- 'UTF-8'
   utils::read.csv(
     text             = iconv(readBin(x$content, character()),
-                                    'UTF-8', 'UTF-8', '\U25a1'),
+                             enc, 'UTF-8', '\U25a1'),
     stringsAsFactors = stringsAsFactors, 
     na.strings       = na.strings,
     ...)
+}

--- a/R/makeApiCall.R
+++ b/R/makeApiCall.R
@@ -261,10 +261,10 @@ makeApiCall <- function(rcon,
 
 # Helper function to convert responses to character strings without crashing.
 # ASSUMPTION: UTF-8 is the only allowed encoding. 
-as.data.frame.response <- function(x, ...)
+as.data.frame.response <- function(x, stringsAsFactors=FALSE, na.strings = "", ...)
   utils::read.csv(
     text             = iconv(readBin(x$content, character()),
                                     'UTF-8', 'UTF-8', '\U25a1'),
-    stringsAsFactors = FALSE, 
-    na.strings       = "",
+    stringsAsFactors = stringsAsFactors, 
+    na.strings       = na.strings,
     ...)

--- a/R/makeApiCall.R
+++ b/R/makeApiCall.R
@@ -258,3 +258,8 @@ makeApiCall <- function(rcon,
   
   message(msg_part1, msg_part2, msg_part3)
 }
+
+# Helper function to convert responses to character strings without crashing.
+# ASSUMPTION: UTF-8 is the only allowed encoding. 
+.safe_as_character_response <- function(x, ...)
+  iconv(readBin(x$content, character()), 'UTF-8', 'UTF-8', '\U25a1')

--- a/tests/testthat/test-050-makeApiCall.R
+++ b/tests/testthat/test-050-makeApiCall.R
@@ -176,12 +176,14 @@ test_that(
 )
 
 test_that(
-  ".safe_as_character_response handles invalid encoded characters",
+  "as.data.frame.response handles invalid encoded characters",
   {
-    x <- list(content=charToRaw("fa\xE7il,joe\n1, 2\n3, 4"))
-    y <- .safe_as_character_response(x)
-    expect_true(grepl("\u25a1",y))
-    expect_equal(read.csv(text=y),
-      data.frame(fa.il=c(1,3), joe=c(2,4)))
+    x <- list(content=charToRaw("fa\xE7il,joe\n1,2\xE7\n3,4"))
+    class(x) <- c("response","list")
+    y <- redcapAPI:::as.data.frame.response(x)
+    expect_equal(
+      y,
+      data.frame(fa.il=as.integer(c(1,3)), joe=c("2\U25a1","4"))
+    )
   }
 )

--- a/tests/testthat/test-050-makeApiCall.R
+++ b/tests/testthat/test-050-makeApiCall.R
@@ -179,6 +179,7 @@ test_that(
   "as.data.frame.response handles invalid encoded characters",
   {
     x <- list(content=charToRaw("fa\xE7il,joe\n1,2\xE7\n3,4"))
+    x[['headers']] <- list('Content-Type'='text/csv; charset=utf-8')
     class(x) <- c("response","list")
     expect_warning({y <- redcapAPI:::as.data.frame.response(x)},
                   "invalid characters")
@@ -186,5 +187,13 @@ test_that(
       y,
       data.frame(fa.il=as.integer(c(1,3)), joe=c("2\U25a1","4"))
     )
+    
+    x[['headers']] <- list('Content-Type'='text/csv') # defaults to latin
+    expect_silent({y <- redcapAPI:::as.data.frame.response(x)})
+    expect_equal(
+      y,
+      data.frame(façil=as.integer(c(1,3)), joe=c("2ç","4"))
+    )
+    
   }
 )

--- a/tests/testthat/test-050-makeApiCall.R
+++ b/tests/testthat/test-050-makeApiCall.R
@@ -174,3 +174,14 @@ test_that(
                  "'config': Must have names")
   }
 )
+
+test_that(
+  ".safe_as_character_response handles invalid encoded characters",
+  {
+    x <- list(content=charToRaw("fa\xE7il,joe\n1, 2\n3, 4"))
+    y <- .safe_as_character_response(x)
+    expect_true(grepl("\u25a1",y))
+    expect_equal(read.csv(text=y),
+      data.frame(fa.il=c(1,3), joe=c(2,4)))
+  }
+)

--- a/tests/testthat/test-050-makeApiCall.R
+++ b/tests/testthat/test-050-makeApiCall.R
@@ -180,7 +180,8 @@ test_that(
   {
     x <- list(content=charToRaw("fa\xE7il,joe\n1,2\xE7\n3,4"))
     class(x) <- c("response","list")
-    y <- redcapAPI:::as.data.frame.response(x)
+    expect_warning({y <- redcapAPI:::as.data.frame.response(x)},
+                  "invalid characters")
     expect_equal(
       y,
       data.frame(fa.il=as.integer(c(1,3)), joe=c("2\U25a1","4"))


### PR DESCRIPTION
In the interest of slaying these bugs, I've prepped this pull request for discussion.

Questions I have:

1) Should we have a warning, or is just \u25a1 substitution sufficient?
2) Would an API reply ever be something besides UTF-8, i.e. should we use the content in the header to define the target encoding?