### PR TITLE
Missing Summary Refactor, broken #339

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: redcapAPI
 Type: Package
 Title: Interface to 'REDCap'
-Version: 2.8.5
+Version: 2.9.0
 Authors@R: c(
     person("Benjamin", "Nutter", email = "benjamin.nutter@gmail.com", 
            role = c("ctb", "aut")),
@@ -52,4 +52,4 @@ URL: https://github.com/vubiostat/redcapAPI
 BugReports: https://github.com/vubiostat/redcapAPI/issues
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,10 @@ A future release of version 3.0.0 will introduce several breaking changes!
 * The `exportProjectInfo` and `exportBundle` functions are being discontinued. Their functionality is replaced by caching values on the connection object.
 * The `cleanseMetaData` function is being discontinued.
 
+## 2.9.0
+
+* Refactor of missingSummary to use exportRecordsTyped. This is a breaking change in prep of 3.0.0
+
 ## 2.8.5
 
 * Minor export optimizations for records.

--- a/man/redcapAPI.Rd
+++ b/man/redcapAPI.Rd
@@ -2,8 +2,8 @@
 % Please edit documentation in R/redcapAPI-package.R
 \docType{package}
 \name{redcapAPI}
-\alias{redcapAPI}
 \alias{redcapAPI-package}
+\alias{redcapAPI}
 \title{Access data, meta data, and files from REDCap using the API}
 \description{
 REDCap is a database development tool built on MySQL.  Visit

--- a/tests/testthat/test-356-missingSummary.R
+++ b/tests/testthat/test-356-missingSummary.R
@@ -3,21 +3,12 @@ context("Missing Summary")
 DesiredOutput <- 
   structure(
     list(
-      record_id = structure(c("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", 
-                              "11", "12", "13", "14", "15", "16", "17", "18", "19", "20"), 
-                            label = "Record ID", 
-                            class = c("labelled", "character")),
-      redcap_event_name = c("event_1_arm_1", "event_1_arm_1", "event_1_arm_1", "event_1_arm_1", 
-                            "event_1_arm_1", "event_1_arm_1", "event_1_arm_1", "event_1_arm_1", 
-                            "event_1_arm_1", "event_1_arm_1", "event_1_arm_1", "event_1_arm_1", 
-                            "event_1_arm_1", "event_1_arm_1", "event_1_arm_1", "event_1_arm_1", 
-                            "event_1_arm_1", "event_1_arm_1", "event_1_arm_1", "event_1_arm_1"),
-      redcap_data_access_group = c(NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, 
-                                   NA, NA, NA, NA, NA, NA, NA, NA, NA, NA),
-      redcap_repeat_instrument = c(NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, 
-                                   NA, NA, NA, NA, NA, NA, NA, NA, NA, NA),
-      redcap_repeat_instance = c(NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, 
-                                 NA, NA, NA, NA, NA, NA, NA, NA, NA, NA),
+      record_id = structure(as.character(1:20), 
+                            label = "Record ID"),
+      redcap_event_name = rep("event_1_arm_1", 20),
+      redcap_data_access_group = rep(NA_real_, 20),
+      redcap_repeat_instrument = rep(NA_real_, 20),
+      redcap_repeat_instance = rep(NA_character_, 20),
       n_missing = c(6, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 5), 
       missing = c("row_purpose, prereq_radio, prereq_number, prereq_date, prereq_yesno, no_prereq_number", 
                   "", 
@@ -57,9 +48,9 @@ test_that(
     local_reproducible_output(width = 200)
     expect_identical(
       missingSummary(rcon,
-                     exportRecordsArgs = list(fields = "record_id", 
-                                              records = as.character(1:20), 
-                                              forms = "branching_logic")), 
+                     fields = "record_id", 
+                     records = as.character(1:20), 
+                     forms = "branching_logic"), 
       DesiredOutput
     )
   }
@@ -102,52 +93,12 @@ test_that(
   }
 )
 
-test_that(
-  "Return an error if exportRecordsArgs is not a list.",
-  # * return an error if exportRecordsArgs is not a named list.
-  # * return an error if exportRecordsArgs has elements that are not arguments to exportRecords.
-  {
-    local_reproducible_output(width = 200)
-    expect_error(
-      missingSummary(rcon, 
-                     exportRecordsArgs = "branching_logic"), 
-      "'exportRecordsArgs': Must be of type 'list'"
-    )
-  }
-)
 
 test_that(
-  "Return an error if exportRecordsArgs is not a named list.",
+  "Validate config, api_param", 
   {
     local_reproducible_output(width = 200)
-    expect_error(
-      missingSummary(rcon, 
-                     exportRecordsArgs = list("branching_logic")), 
-      "'exportRecordsArgs': Must have names"
-    )
-  }
-)
-
-test_that(
-  "Return an error if `fixed_fields` is not a character vector",
-  {
-    local_reproducible_output(width = 200)
-    expect_error(
-      missingSummary(rcon, 
-                     fixed_fields = 1:3), 
-      "Variable 'fixed_fields': Must be of type 'character'"
-    )
-  }
-)
-
-test_that(
-  "Validate error_handling, config, api_param", 
-  {
-    local_reproducible_output(width = 200)
-    expect_error(missingSummary(rcon, 
-                                error_handling = "not an option"), 
-                 "'error[_]handling': Must be element of set [{]'null','error'[}]")
-    
+   
     expect_error(missingSummary(rcon, 
                                 config = list(1)), 
                  "'config': Must have names")
@@ -161,5 +112,10 @@ test_that(
     expect_error(missingSummary(rcon, 
                                 api_param = "not a list"), 
                  "'api_param': Must be of type 'list'")
+    
+    expect_silent(missingSummary(rcon,
+                                 exportRecordsArgs = list(fields = "record_id", 
+                                                          records = as.character(1:20), 
+                                                          forms = "branching_logic")))
   }
 )


### PR DESCRIPTION
I've attempted to refactor missingSummary to use exportRecordsTyped, and the preferred new interface. It fails the key test and I have not been able to figure out why. 