### PR TITLE
Tests stop if missing codes are defined. #350

### DIFF
--- a/tests/testthat/helper-00-REDCapQACredentials.R
+++ b/tests/testthat/helper-00-REDCapQACredentials.R
@@ -46,7 +46,7 @@ conns <- unlockREDCap(
 #     ), 
 #   url=url, keyring='API_KEYs')
 
-missing_codes <- rcon$projectInformation()$missing_data_codes
+missing_codes <- conns$rcon$projectInformation()$missing_data_codes
 
 if(!is.na(missing_codes) && nchar(missing_codes) > 0)
   stop("The test suite will fail if missing data codes are defined in the project.")

--- a/tests/testthat/helper-00-REDCapQACredentials.R
+++ b/tests/testthat/helper-00-REDCapQACredentials.R
@@ -30,8 +30,8 @@ conns <- unlockREDCap(
   ############################################################################
  #
 #  Uncomment to create all API Keys with names in keylocker,
-#  with TestRedcapAPI being ones default. This allows me to change the above
-#  rcon easily for my desired target. For convenience, the REPORT_IDS
+#  with TestRedcapAPI being ones default. This allows one to change the above
+#  rcon easily for desired target. For convenience, the REPORT_IDS
 #  for each environment is listed as well
 #
 # unlockREDCap(

--- a/tests/testthat/helper-00-REDCapQACredentials.R
+++ b/tests/testthat/helper-00-REDCapQACredentials.R
@@ -22,11 +22,31 @@ library(keyring)
 url <- "https://redcap.vanderbilt.edu/api/" # Our institutions REDCap instance
 
 conns <- unlockREDCap(
-  c(rcon ="TestRedcapAPI"), ## Change to rcon when satisfied with testing
- # c(rcon = "DataTypes"),        ## Delete this to change to primary project
+  #c(rcon ="TestRedcapAPI"),
+  c(rcon = "ShawnTest"),
   url=url, keyring='API_KEYs', 
   envir=globalenv())
 
+  ############################################################################
+ #
+#  Uncomment to create all API Keys with names in keylocker,
+#  with TestRedcapAPI being ones default. This allows me to change the above
+#  rcon easily for my desired target. For convenience, the REPORT_IDS
+#  for each environment is listed as well
+#
+# unlockREDCap(
+#   c(rcon = "TestRedcapAPI", # Desired default, Sys.setenv(REPORT_IDS=NULL)
+#     a1   = "SandboxTest",   # pid 167416, Sys.setenv(REPORT_IDS=410354)
+#     a2   = "QATest",        # pid 167509, Sys.setenv(REPORT_IDS='357209,362756')
+#     a3   = "DevTest",       # pid 167805, Sys.setenv(REPORT_IDS='362274,375181')
+#     a4   = "ExprTest",      # pid 174218, Sys.setenv(REPORT_IDS='371898,371899')
+#     a5   = "ThomasTest",    # pid 178186, Sys.setenv(REPORT_IDS='384516,384517')
+#     a6   = "ShawnTest",     # pid 188425, Sys.setenv(REPORT_IDS=NULL
+#     a7   = "DQTest"         # pid 133406, Sys.setenv(REPORT_IDS=417554)
+#     ), 
+#   url=url, keyring='API_KEYs')
 
+missing_codes <- rcon$projectInformation()$missing_data_codes
 
-
+if(!is.na(missing_codes) && nchar(missing_codes) > 0)
+  stop("The test suite will fail if missing data codes are defined in the project.")

--- a/tests/testthat/helper-00-REDCapQACredentials.R
+++ b/tests/testthat/helper-00-REDCapQACredentials.R
@@ -22,8 +22,8 @@ library(keyring)
 url <- "https://redcap.vanderbilt.edu/api/" # Our institutions REDCap instance
 
 conns <- unlockREDCap(
-  #c(rcon ="TestRedcapAPI"),
-  c(rcon = "ShawnTest"),
+  c(rcon ="TestRedcapAPI"), # Your default from keyring
+  #c(rcon = "YourChoiceOfKeyHere"),
   url=url, keyring='API_KEYs', 
   envir=globalenv())
 
@@ -35,14 +35,14 @@ conns <- unlockREDCap(
 #  for each environment is listed as well
 #
 # unlockREDCap(
-#   c(rcon = "TestRedcapAPI", # Desired default, Sys.setenv(REPORT_IDS=NULL)
+#   c(rcon = "TestRedcapAPI", # Desired default, Get REPORT_ID from below list
 #     a1   = "SandboxTest",   # pid 167416, Sys.setenv(REPORT_IDS=410354)
 #     a2   = "QATest",        # pid 167509, Sys.setenv(REPORT_IDS='357209,362756')
 #     a3   = "DevTest",       # pid 167805, Sys.setenv(REPORT_IDS='362274,375181')
 #     a4   = "ExprTest",      # pid 174218, Sys.setenv(REPORT_IDS='371898,371899')
 #     a5   = "ThomasTest",    # pid 178186, Sys.setenv(REPORT_IDS='384516,384517')
-#     a6   = "ShawnTest",     # pid 188425, Sys.setenv(REPORT_IDS=NULL
-#     a7   = "DQTest"         # pid 133406, Sys.setenv(REPORT_IDS=417554)
+#     a6   = "ShawnTest",     # pid 188425, Sys.setenv(REPORT_IDS=417554)
+#     a7   = "DQTest"         # pid 133406, Sys.setenv(REPORT_IDS=NULL)
 #     ), 
 #   url=url, keyring='API_KEYs')
 


### PR DESCRIPTION
This should stop the test with a clear message. Also, added some instructions on switching projects easily. 