### PR TITLE
Correctly assign form_complete field types

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,7 @@ A future release of version 3.0.0 will introduce several breaking changes!
 
 * Refactored error handling on API calls to reduce code footprint.
 * Added `redcap_survey_identifier` to system field list.
+* Bug fix for handling fields ending in '_complete' that are not form related.
 
 ## 2.9.1
 

--- a/R/fieldCastingFunctions.R
+++ b/R/fieldCastingFunctions.R
@@ -641,7 +641,10 @@ mChoiceCast <- function(data,
                                        field_text_types){
 
   field_types <- rcon$metadata()$field_type[field_map]
-  field_types[grepl("_complete$", field_bases)] <- "form_complete"
+  
+  # only select form_name with _complete, avoid fields that end in _complete
+  form_complete_names <- paste0(unique(rcon$metadata()$form_name), "_complete")
+  field_types[field_bases %in% form_complete_names] <- "form_complete"
   
   choices <- rcon$metadata()$select_choices_or_calculations[field_map]
   


### PR DESCRIPTION
assign form_complete field type to fields where the form name followed by _complete is found