### PR TITLE
add badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10602052.svg)](https://doi.org/10.5281/zenodo.10602052)
 ![](https://cranlogs.r-pkg.org/badges/grand-total/redcapAPI)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL_v2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
+![r-cmd-check.yml](https://github.com/vubiostat/redcapAPI/actions/workflows/r-cmd-check.yml/badge.svg?branch=main)
 
 redcapAPI
 =========


### PR DESCRIPTION
Hi team,

I’ve added a new badge to the README file to display the status of the GitHub Action for R CMD check. This badge will help us quickly see the build status and ensure our code passes the necessary checks.