### PR TITLE
Issue 389 vectorize renameRecord and exportFieldNames

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,4 +54,4 @@ URL: https://github.com/vubiostat/redcapAPI
 BugReports: https://github.com/vubiostat/redcapAPI/issues
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: redcapAPI
 Type: Package
 Title: Interface to 'REDCap'
-Version: 2.10.0
+Version: 2.10.1
 Authors@R: c(
     person("Benjamin", "Nutter", email = "benjamin.nutter@gmail.com", 
            role = c("ctb", "aut")),

--- a/NEWS
+++ b/NEWS
@@ -10,9 +10,13 @@ A future release of version 3.0.0 will introduce several breaking changes!
 * The `exportProjectInfo` and `exportBundle` functions are being discontinued. Their functionality is replaced by caching values on the connection object.
 * The `cleanseMetaData` function is being discontinued.
 
+## 2.10.1
+
+* Vectorized `renameRecord` and `exportFieldNames`
+
 ## 2.10.0
 
-* Replace "httr" dependency with "curl"
+* Replace `httr` dependency with `curl`
 
 ## 2.9.4
 

--- a/R/docsRecordsManagementMethods.R
+++ b/R/docsRecordsManagementMethods.R
@@ -10,14 +10,14 @@
 #' @param record_name `character` or `integerish`. 
 #'   The name of an existing record in the project. 
 #' @param new_record_name `character` or `integerish`. 
-#'   The new name to give to the record. Must have the same lenght as
+#'   The new name to give to the record. Must have the same length as
 #'   `record_name`.
 #' @param arm `character` or `NULL`, an optional arm number. 
 #'   If `NULL`, then all records with same name across all arms on 
 #'   which it exists (if longitudinal with multiple arms) will be 
 #'   renamed to new record name, otherwise it will rename the record 
 #'   only in the specified arm. When not `NULL`, it must have the same 
-#'   length at `record_name`.
+#'   length as `record_name`.
 #'   
 #' @return
 #' `exportNextRecordName` returns an integerish value. The value is

--- a/R/docsRecordsManagementMethods.R
+++ b/R/docsRecordsManagementMethods.R
@@ -7,22 +7,24 @@
 #' @inheritParams common-rcon-arg
 #' @inheritParams common-dot-args
 #' @inheritParams common-api-args
-#' @param record_name `character(1)` or `integerish(1)`. 
+#' @param record_name `character` or `integerish`. 
 #'   The name of an existing record in the project. 
-#' @param new_record_name `character(1)` or `integerish(1)`. 
-#'   The new name to give to the record. 
-#' @param arm `character(1)` or `NULL`, an optional arm number. 
+#' @param new_record_name `character` or `integerish`. 
+#'   The new name to give to the record. Must have the same lenght as
+#'   `record_name`.
+#' @param arm `character` or `NULL`, an optional arm number. 
 #'   If `NULL`, then all records with same name across all arms on 
 #'   which it exists (if longitudinal with multiple arms) will be 
 #'   renamed to new record name, otherwise it will rename the record 
-#'   only in the specified arm.
+#'   only in the specified arm. When not `NULL`, it must have the same 
+#'   length at `record_name`.
 #'   
 #' @return
 #' `exportNextRecordName` returns an integerish value. The value is
 #'   determined by looking up the highest record ID number in the 
 #'   project and incrementing it by 1. 
 #'
-#' `renameRecord` invisibly returns a logical value that indicates if the 
+#' `renameRecord` invisibly returns a logical vector that indicates if the 
 #'   operation was successful. Otherwise, an error is thrown.
 #'   
 #'   

--- a/R/renameRecord.R
+++ b/R/renameRecord.R
@@ -34,29 +34,55 @@ renameRecord.redcapApiConnection <- function(rcon,
                           add = coll)
   
   checkmate::assert_character(x = record_name, 
-                              len = 1, 
                               add = coll)
   
   checkmate::assert_character(x = new_record_name, 
-                              len = 1, 
+                              len = length(record_name), 
                               add = coll)
   
   checkmate::assert_character(x = arm, 
-                              len = 1, 
+                              len = length(record_name), 
                               null.ok = TRUE, 
                               add = coll)
 
   checkmate::reportAssertions(coll)
   
+  
+  ###################################################################
+  # Rename the records
+
+  results <- 
+    mapply(.renameRecordApiCall, 
+           record_name = record_name, 
+           new_record_name = new_record_name, 
+           arm = if (is.null(arm)) lapply(record_name, function(r) NULL)
+                 else arm,
+           MoreArgs = list(rcon = rcon),
+           ...,
+           SIMPLIFY = TRUE, 
+           USE.NAMES = FALSE)
+  
+  invisible(results)
+}
+
+
+#####################################################################
+# Unexported                                                     ####
+
+.renameRecordApiCall <- function(rcon, 
+                                 record_name, 
+                                 new_record_name, 
+                                 arm, 
+                                 ...){
   ###################################################################
   # API Body List                                                ####
-  
+
   body <- list(content = "record", 
                action = "rename", 
                record = record_name, 
                new_record_name = new_record_name, 
                arm = arm)
-
+  
   ###################################################################
   # Call the API                                                 ####
   invisible('1' == as.character(makeApiCall(rcon, body, ...)))

--- a/R/unlockREDCap.R
+++ b/R/unlockREDCap.R
@@ -63,7 +63,7 @@
   # Hacked work around for RStudio starting new session for everything
   if(requireNamespace("rstudioapi", quietly = TRUE) &&
      rstudioapi::isAvailable(child_ok=TRUE))
-    rstudioapi::sendToConsole(sprintf("Sys.setenv(REDCAPAPI_PW='%s')", password), execute = TRUE, echo=FALSE)
+    rstudioapi::sendToConsole(sprintf("Sys.setenv(REDCAPAPI_PW='%s')", password), execute = TRUE, echo=FALSE, focus=FALSE)
 }
 
 .clearPWGlobalEnv <- function()
@@ -72,7 +72,7 @@
   # Hacked work around for RStudio starting new session for everything
   if(requireNamespace("rstudioapi", quietly = TRUE) &&
      rstudioapi::isAvailable(child_ok=TRUE))
-    rstudioapi::sendToConsole('Sys.unsetenv("REDCAPAPI_PW")', execute = TRUE, echo=FALSE)
+    rstudioapi::sendToConsole('Sys.unsetenv("REDCAPAPI_PW")', execute = TRUE, echo=FALSE, focus=FALSE)
 }
 
 .getPWGlobalEnv <- function()

--- a/R/unlockREDCap.R
+++ b/R/unlockREDCap.R
@@ -63,7 +63,7 @@
   # Hacked work around for RStudio starting new session for everything
   if(requireNamespace("rstudioapi", quietly = TRUE) &&
      rstudioapi::isAvailable(child_ok=TRUE))
-    rstudioapi::sendToConsole(sprintf("Sys.setenv(REDCAPAPI_PW='%s')", password), execute = TRUE, echo=FALSE, focus=FALSE)
+    rstudioapi::sendToConsole(sprintf("Sys.setenv(REDCAPAPI_PW='%s')", password), execute = TRUE, echo=FALSE)
 }
 
 .clearPWGlobalEnv <- function()
@@ -72,7 +72,7 @@
   # Hacked work around for RStudio starting new session for everything
   if(requireNamespace("rstudioapi", quietly = TRUE) &&
      rstudioapi::isAvailable(child_ok=TRUE))
-    rstudioapi::sendToConsole('Sys.unsetenv("REDCAPAPI_PW")', execute = TRUE, echo=FALSE, focus=FALSE)
+    rstudioapi::sendToConsole('Sys.unsetenv("REDCAPAPI_PW")', execute = TRUE, echo=FALSE)
 }
 
 .getPWGlobalEnv <- function()

--- a/man/exportFieldNames.Rd
+++ b/man/exportFieldNames.Rd
@@ -13,7 +13,7 @@ exportFieldNames(rcon, ...)
 \arguments{
 \item{rcon}{A \code{redcapConnection} object.}
 
-\item{fields}{\code{NULL} or \code{character(1)}. Field name to be returned.  By
+\item{fields}{\code{NULL} or \code{character}. Field name to be returned.  By
 default, all fields are returned.}
 
 \item{...}{Arguments to pass to other methods}

--- a/man/recordsManagementMethods.Rd
+++ b/man/recordsManagementMethods.Rd
@@ -24,7 +24,7 @@ renameRecord(rcon, record_name, new_record_name, arm = NULL, ...)
 The name of an existing record in the project.}
 
 \item{new_record_name}{\code{character} or \code{integerish}.
-The new name to give to the record. Must have the same lenght as
+The new name to give to the record. Must have the same length as
 \code{record_name}.}
 
 \item{arm}{\code{character} or \code{NULL}, an optional arm number.
@@ -32,7 +32,7 @@ If \code{NULL}, then all records with same name across all arms on
 which it exists (if longitudinal with multiple arms) will be
 renamed to new record name, otherwise it will rename the record
 only in the specified arm. When not \code{NULL}, it must have the same
-length at \code{record_name}.}
+length as \code{record_name}.}
 
 \item{...}{Arguments to pass to other methods}
 }

--- a/man/recordsManagementMethods.Rd
+++ b/man/recordsManagementMethods.Rd
@@ -20,17 +20,19 @@ renameRecord(rcon, record_name, new_record_name, arm = NULL, ...)
 \arguments{
 \item{rcon}{A \code{redcapConnection} object.}
 
-\item{record_name}{\code{character(1)} or \code{integerish(1)}.
+\item{record_name}{\code{character} or \code{integerish}.
 The name of an existing record in the project.}
 
-\item{new_record_name}{\code{character(1)} or \code{integerish(1)}.
-The new name to give to the record.}
+\item{new_record_name}{\code{character} or \code{integerish}.
+The new name to give to the record. Must have the same lenght as
+\code{record_name}.}
 
-\item{arm}{\code{character(1)} or \code{NULL}, an optional arm number.
+\item{arm}{\code{character} or \code{NULL}, an optional arm number.
 If \code{NULL}, then all records with same name across all arms on
 which it exists (if longitudinal with multiple arms) will be
 renamed to new record name, otherwise it will rename the record
-only in the specified arm.}
+only in the specified arm. When not \code{NULL}, it must have the same
+length at \code{record_name}.}
 
 \item{...}{Arguments to pass to other methods}
 }
@@ -39,7 +41,7 @@ only in the specified arm.}
 determined by looking up the highest record ID number in the
 project and incrementing it by 1.
 
-\code{renameRecord} invisibly returns a logical value that indicates if the
+\code{renameRecord} invisibly returns a logical vector that indicates if the
 operation was successful. Otherwise, an error is thrown.
 }
 \description{

--- a/tests/testthat/test-108-metadataMethods-Functionality.R
+++ b/tests/testthat/test-108-metadataMethods-Functionality.R
@@ -48,4 +48,4 @@ test_that(
 )
 
 # Clean up 
-importMetaData(rcon, MetaData[1, ])
+importMetaData(rcon, test_redcapAPI_MetaData[1, ])

--- a/tests/testthat/test-108-metadataMethods-Functionality.R
+++ b/tests/testthat/test-108-metadataMethods-Functionality.R
@@ -28,8 +28,24 @@ test_that(
     
     expect_equal(rcon$instruments()$instrument_name, 
                  unique(NextMetaData$form_name))
-    
-    # Clean up 
-    importMetaData(rcon, MetaData[1, ])
   }
 )
+
+
+test_that(
+  "Export Field Names testing", 
+  {
+    Fields <- exportFieldNames(rcon)
+    expect_true(nrow(Fields) > 0)
+    
+    Fields <- exportFieldNames(rcon, "record_id")
+    expect_true(nrow(Fields) == 1)
+    
+    Fields <- exportFieldNames(rcon, 
+                               fields = rcon$metadata()$field_name[1:2])
+    expect_true(nrow(Fields) == 2)
+  }
+)
+
+# Clean up 
+importMetaData(rcon, MetaData[1, ])

--- a/tests/testthat/test-358-renameRecord-ArgumentValidation.R
+++ b/tests/testthat/test-358-renameRecord-ArgumentValidation.R
@@ -11,18 +11,8 @@ test_that(
 )
 
 test_that(
-  "Return an error if record_name is not character(1)", 
+  "Return an error if record_name is not character", 
   {
-    expect_error(renameRecord(rcon, 
-                              record_name = c("1", "2"), 
-                              new_record_name = "100"), 
-                 "'record_name': Must have length 1")
-    
-    expect_error(renameRecord(rcon, 
-                              record_name = 1:2, 
-                              new_record_name = "100"), 
-                 "'record_name': Must have length 1")
-    
     expect_error(renameRecord(rcon, 
                               record_name = FALSE, 
                               new_record_name = "100"), 
@@ -33,16 +23,6 @@ test_that(
 test_that(
   "Return an error if new_record_name is not character(1)", 
   {
-    expect_error(renameRecord(rcon, 
-                              record_name = "1", 
-                              new_record_name = c("100", "101")), 
-                 "'new_record_name': Must have length 1")
-    
-    expect_error(renameRecord(rcon, 
-                              record_name = 1, 
-                              new_record_name = c("100", "101")), 
-                 "'new_record_name': Must have length 1")
-    
     expect_error(renameRecord(rcon, 
                               record_name = "1", 
                               new_record_name = FALSE), 
@@ -56,42 +36,7 @@ test_that(
     expect_error(renameRecord(rcon, 
                               record_name = "1", 
                               new_record_name = "100", 
-                              arm = c("1", "2")), 
-                 "Variable 'arm': Must have length 1")
-    
-    expect_error(renameRecord(rcon, 
-                              record_name = "1", 
-                              new_record_name = "100", 
                               arm = TRUE), 
                  "Variable 'arm': Must be of type 'character'")
-  }
-)
-
-test_that(
-  "Validate config, api_param", 
-  {
-    local_reproducible_output(width = 200)
-   
-    expect_error(renameRecord(rcon, 
-                              record_name = "1", 
-                              new_record_name = "100", 
-                              config = list(1)), 
-                 "'config': Must have names")
-    expect_error(renameRecord(rcon, 
-                              record_name = "1", 
-                              new_record_name = "100",
-                              config = "not a list"), 
-                 "'config': Must be of type 'list'")
-    
-    expect_error(renameRecord(rcon, 
-                              record_name = "1", 
-                              new_record_name = "100", 
-                              api_param = list(1)), 
-                 "'api_param': Must have names")
-    expect_error(renameRecord(rcon, 
-                              record_name = "1", 
-                              new_record_name = "100",
-                              api_param = "not a list"), 
-                 "'api_param': Must be of type 'list'")
   }
 )

--- a/tests/testthat/test-358-renameRecord-Functionality.R
+++ b/tests/testthat/test-358-renameRecord-Functionality.R
@@ -22,3 +22,19 @@ test_that(
     expect_false("100" %in% Rec$record_id)
   }
 )
+
+
+test_that(
+  "Rename multiple records", 
+  {
+    expect_equal(renameRecord(rcon, 
+                              record_name = c("1", "2"), 
+                              new_record_name = c("101", "102")), 
+                 c(TRUE, TRUE))
+    
+    expect_equal(renameRecord(rcon, 
+                              record_name = c("101", "102"), 
+                              new_record_name = c("1", "2")), 
+                 c(TRUE, TRUE))
+  }
+)


### PR DESCRIPTION
* vectorizes `renameRecord` and `exportFieldNames`
* Adds tests for vectorized forms

`renameRecord` requires that the arguments `record_name` and `new_record` name be the same length. It `arms` is not `NULL` it must also be the same length. 

`renameRecord` returns a vector of `TRUE/FALSE`. it is unnamed, but gives an indication of which calls succeeded or failed.

`exportFieldNames` returns a data frame, as is always has.