### PR TITLE
robust to NULL osVersion

### DIFF
--- a/R/unlockREDCap.R
+++ b/R/unlockREDCap.R
@@ -195,8 +195,8 @@
 ## when knitting from RStudio, ugh.
 .default_pass <- function()
 {
-  if(grepl('mac', tolower(utils::osVersion))        &&
-     requireNamespace("rstudioapi", quietly = TRUE) &&
+  if(isTRUE(grepl('mac', tolower(utils::osVersion))) &&
+     requireNamespace("rstudioapi", quietly = TRUE)  &&
      rstudioapi::isAvailable(child_ok=TRUE))
   {
     rstudioapi::askForPassword


### PR DESCRIPTION
`osVersion` can be `NULL` (`?osVersion`). That would break the `if()` check (`if (logical())`). This `isTRUE()` wrapper is the simplest fix.