### PR TITLE
API correctly returns forms_export now

### DIFF
--- a/R/exportUserRoles.R
+++ b/R/exportUserRoles.R
@@ -49,14 +49,6 @@ exportUserRoles.redcapApiConnection <- function(rcon,
 
   if (nrow(UserRole) == 0) return(redcapUserRoleStructure(rcon$version()))
 
-  # The API returns the forms_export string twice.  We reduce it to once here
-  temp <- UserRole$forms_export
-  temp <- strsplit(temp, ",")
-  temp <- unlist(temp)
-  temp <- temp[!duplicated(temp)]
-  temp <- paste0(temp, collapse = ",")
-  UserRole$forms_export <- temp
-
   ###################################################################
   # Format UserRole properties                                   ####
 


### PR DESCRIPTION
At some point this code was added to fix a bug in the API's export of UserRole's. Unfortunately, it wasn't implemented correctly (as #503 notes). Fortunately, it's no longer necessary as the API returns the correct text ("forms_export" is not duplicated).